### PR TITLE
Add Confluence search agent tool

### DIFF
--- a/python-agent-tools/create-confluence-page/tool.json
+++ b/python-agent-tools/create-confluence-page/tool.json
@@ -1,0 +1,33 @@
+{
+    "id": "create-confluence-page",
+    "meta": {
+        "icon": "icon-file-text-alt",
+        "label": "Create Confluence Page",
+        "description": "Create a Confluence page based on user input"
+    },
+    "params": [
+        {
+            "name": "access_type",
+            "label": "Access type. Reviewer: hidden menu to keep for future extension",
+            "visibilityCondition": "false",
+            "type": "SELECT",
+            "defaultValue": "token_access",
+            "selectChoices": [
+                {"value": "token_access", "label": "Token"}
+            ]
+        },
+        {
+            "name": "token_access",
+            "label": "Confluence connection",
+            "type": "PRESET",
+            "parameterSetId": "basic-auth",
+            "visibilityCondition": "model.access_type == 'token_access'"
+        },
+        {
+            "type": "STRING",
+            "name": "spaceKey",
+            "label": "Space key",
+            "mandatory": true
+        }
+    ]
+}

--- a/python-agent-tools/create-confluence-page/tool.py
+++ b/python-agent-tools/create-confluence-page/tool.py
@@ -1,0 +1,72 @@
+from dataiku.llm.agent_tools import BaseAgentTool
+import logging
+from utils import get_connection_details
+from confluence_client import ConfluenceClient
+
+
+class ConfluenceCreatePageTool(BaseAgentTool):
+    def set_config(self, config, plugin_config):
+        logging.getLogger("jiraapiclient.discovery").setLevel("INFO")
+        logging.info("ConfluenceCreatePageTool init")
+        self.config = config
+        connection_details = get_connection_details(config)
+        self.client = ConfluenceClient(connection_details)
+        self.space_key = config.get("spaceKey")
+
+    def get_descriptor(self, tool):
+        return {
+            "description": "This tool creates a Confluence page in the configured space. The input must contain the page title and content.",
+            "inputSchema": {
+                "$id": "https://dataiku.com/agents/tools/search/input",
+                "title": "Create Confluence page tool",
+                "type": "object",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "description": "The page title",
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "The page content in Confluence storage format",
+                    },
+                },
+                "required": ["title", "content"],
+            },
+        }
+
+    def create_confluence_page(self, space_key: str, title: str, content: str):
+        try:
+            new_page = self.client.create_page(title, content, space_key)
+            return new_page
+        except Exception as exception:
+            return f"Error creating page: {str(exception)}"
+
+    def invoke(self, input, trace):
+        args = input.get("input", {})
+        title = args.get("title")
+        content = args.get("content")
+        space_key = self.space_key
+        confluence_instance_url = self.client.site_url
+
+        trace.span["name"] = "CONFLUENCE_CREATE_PAGE_TOOL_CALL"
+        for key, value in args.items():
+            trace.inputs[key] = value
+        trace.attributes["config"] = {
+            "confluence_instance_url": confluence_instance_url,
+            "space_key": space_key,
+        }
+
+        created_page = self.create_confluence_page(space_key, title, content)
+
+        if isinstance(created_page, dict) and created_page.get("id"):
+            output_text = (
+                f"Page created: {created_page.get('id')} available at {confluence_instance_url}pages/{created_page.get('id')}"
+            )
+        elif isinstance(created_page, dict) and created_page.get("message"):
+            output_text = f"There was a problem while creating the page: {created_page.get('message')}"
+        else:
+            output_text = str(created_page)
+
+        trace.outputs["output"] = output_text
+
+        return {"output": output_text}

--- a/python-agent-tools/search-confluence-pages/tool.json
+++ b/python-agent-tools/search-confluence-pages/tool.json
@@ -1,0 +1,27 @@
+{
+    "id": "search-confluence-pages",
+    "meta": {
+        "icon": "icon-search",
+        "label": "Search Confluence Pages",
+        "description": "Search Confluence pages by keywords and return the first three results"
+    },
+    "params": [
+        {
+            "name": "access_type",
+            "label": "Access type. Reviewer: hidden menu to keep for future extension",
+            "visibilityCondition": "false",
+            "type": "SELECT",
+            "defaultValue": "token_access",
+            "selectChoices": [
+                {"value": "token_access", "label": "Token"}
+            ]
+        },
+        {
+            "name": "token_access",
+            "label": "Confluence connection",
+            "type": "PRESET",
+            "parameterSetId": "basic-auth",
+            "visibilityCondition": "model.access_type == 'token_access'"
+        }
+    ]
+}

--- a/python-agent-tools/search-confluence-pages/tool.py
+++ b/python-agent-tools/search-confluence-pages/tool.py
@@ -1,0 +1,86 @@
+from dataiku.llm.agent_tools import BaseAgentTool
+import json
+import logging
+from utils import get_connection_details
+from confluence_client import ConfluenceClient
+
+
+class ConfluenceSearchPagesTool(BaseAgentTool):
+    def set_config(self, config, plugin_config):
+        logging.getLogger("jiraapiclient.discovery").setLevel("INFO")
+        logging.info("ConfluenceSearchPagesTool init")
+        self.config = config
+        connection_details = get_connection_details(config)
+        self.client = ConfluenceClient(connection_details)
+
+    def get_descriptor(self, tool):
+        return {
+            "description": "This tool searches Confluence pages using the provided keywords and returns up to three results with their URLs, titles, and page content.",
+            "inputSchema": {
+                "$id": "https://dataiku.com/agents/tools/search/input",
+                "title": "Search Confluence pages tool",
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Keywords to search for in Confluence pages",
+                    }
+                },
+                "required": ["query"],
+            },
+        }
+
+    def search_pages(self, query: str):
+        try:
+            return self.client.search_pages(query, limit=3)
+        except Exception as exception:
+            return f"Error searching pages: {str(exception)}"
+
+    def invoke(self, input, trace):
+        args = input.get("input", {})
+        query = args.get("query")
+        confluence_instance_url = self.client.site_url
+
+        trace.span["name"] = "CONFLUENCE_SEARCH_PAGES_TOOL_CALL"
+        for key, value in args.items():
+            trace.inputs[key] = value
+        trace.attributes["config"] = {
+            "confluence_instance_url": confluence_instance_url,
+        }
+
+        search_result = self.search_pages(query)
+
+        if isinstance(search_result, dict) and search_result.get("results"):
+            items = []
+            for item in search_result.get("results", [])[:3]:
+                content = item.get("content", {})
+                title = content.get("title", "Untitled")
+                page_id = content.get("id")
+                if page_id:
+                    link = f"{confluence_instance_url}pages/{page_id}"
+                    page_data = self.client.get_page_content(page_id)
+                    page_content = (
+                        page_data.get("body", {})
+                        .get("storage", {})
+                        .get("value", "")
+                        if isinstance(page_data, dict)
+                        else ""
+                    )
+                    items.append(
+                        {
+                            "url": link,
+                            "title": title,
+                            "page_content": page_content,
+                        }
+                    )
+            output_data = items if items else []
+        elif isinstance(search_result, dict) and search_result.get("message"):
+            output_data = {
+                "error": f"There was a problem while searching pages: {search_result.get('message')}"
+            }
+        else:
+            output_data = {"error": str(search_result)}
+
+        trace.outputs["results"] = output_data
+
+        return {"output": json.dumps(output_data), "results": output_data}

--- a/python-lib/confluence_client.py
+++ b/python-lib/confluence_client.py
@@ -1,0 +1,71 @@
+import requests
+import logging
+from jira_client import normalize_url
+
+logger = logging.getLogger(__name__)
+
+
+class ConfluenceClient(object):
+    CONFLUENCE_SITE_URL = "https://{subdomain}.atlassian.net/wiki"
+
+    def __init__(self, connection_details):
+        logger.info("ConfluenceClient init")
+        self.server_type = connection_details.get("server_type", "cloud")
+        self.subdomain = connection_details.get("subdomain")
+        self.api_url = normalize_url(connection_details.get("api_url", ""))
+        self.username = connection_details.get("username", "")
+        self.password = connection_details.get("token", "")
+        self.ignore_ssl_check = connection_details.get("ignore_ssl_check", False)
+        self.site_url = self.get_site_url()
+
+    def get_site_url(self):
+        if self.server_type == "cloud":
+            return normalize_url(self.CONFLUENCE_SITE_URL.format(subdomain=self.subdomain))
+        else:
+            return normalize_url(self.api_url)
+
+    def create_page(self, title, content, space_key):
+        url = f"{self.site_url}rest/api/content"
+        data = {
+            "type": "page",
+            "title": title,
+            "space": {"key": space_key},
+            "body": {
+                "storage": {"value": content, "representation": "storage"}
+            },
+        }
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        response = requests.post(
+            url,
+            json=data,
+            auth=(self.username, self.password),
+            headers=headers,
+            verify=not self.ignore_ssl_check,
+        )
+        return response.json()
+
+    def search_pages(self, query, limit=3):
+        url = f"{self.site_url}rest/api/search"
+        params = {"cql": f'text~"{query}"', "limit": limit}
+        headers = {"Accept": "application/json"}
+        response = requests.get(
+            url,
+            params=params,
+            auth=(self.username, self.password),
+            headers=headers,
+            verify=not self.ignore_ssl_check,
+        )
+        return response.json()
+
+    def get_page_content(self, page_id):
+        url = f"{self.site_url}rest/api/content/{page_id}"
+        params = {"expand": "body.storage"}
+        headers = {"Accept": "application/json"}
+        response = requests.get(
+            url,
+            params=params,
+            auth=(self.username, self.password),
+            headers=headers,
+            verify=not self.ignore_ssl_check,
+        )
+        return response.json()


### PR DESCRIPTION
## Summary
- add search_pages method to Confluence client
- introduce ConfluenceSearchPagesTool to search pages by keywords and return top three results with URL, title, and page content

## Testing
- `python -m py_compile python-lib/confluence_client.py python-agent-tools/search-confluence-pages/tool.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6185a0bbc83279a05dbd9506e9d6f