### PR TITLE
Add optional space filter to Confluence search tool

### DIFF
--- a/python-agent-tools/search-confluence-pages/tool.json
+++ b/python-agent-tools/search-confluence-pages/tool.json
@@ -22,6 +22,13 @@
             "type": "PRESET",
             "parameterSetId": "basic-auth",
             "visibilityCondition": "model.access_type == 'token_access'"
+        },
+        {
+            "name": "space_key",
+            "label": "Confluence space key",
+            "type": "STRING",
+            "description": "Optional key of the Confluence space to restrict the search. Leave empty to search all spaces.",
+            "optional": true
         }
     ]
 }

--- a/python-agent-tools/search-confluence-pages/tool.py
+++ b/python-agent-tools/search-confluence-pages/tool.py
@@ -25,21 +25,26 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
                     "query": {
                         "type": "string",
                         "description": "Keywords to search for in Confluence pages",
-                    }
+                    },
+                    "space_key": {
+                        "type": "string",
+                        "description": "Optional Confluence space key to restrict the search. Leave empty to search all spaces.",
+                    },
                 },
                 "required": ["query"],
             },
         }
 
-    def search_pages(self, query: str):
+    def search_pages(self, query: str, space_key: str = None):
         try:
-            return self.client.search_pages(query, limit=3)
+            return self.client.search_pages(query, limit=3, space_key=space_key)
         except Exception as exception:
             return f"Error searching pages: {str(exception)}"
 
     def invoke(self, input, trace):
         args = input.get("input", {})
         query = args.get("query")
+        space_key = args.get("space_key") or None
         confluence_instance_url = self.client.site_url or ""
         base_url = (
             f"{confluence_instance_url.rstrip('/')}/"
@@ -54,7 +59,7 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
             "confluence_instance_url": confluence_instance_url,
         }
 
-        search_result = self.search_pages(query)
+        search_result = self.search_pages(query, space_key)
 
         if isinstance(search_result, dict) and search_result.get("results"):
             items = []

--- a/python-lib/confluence_client.py
+++ b/python-lib/confluence_client.py
@@ -44,9 +44,14 @@ class ConfluenceClient(object):
         )
         return response.json()
 
-    def search_pages(self, query, limit=3):
+    def search_pages(self, query, limit=3, space_key=None):
         url = f"{self.site_url}rest/api/search"
-        params = {"cql": f'text~"{query}"', "limit": limit}
+        cql_parts = [f'text~"{query}"']
+        if space_key:
+            cql_parts.append(f'space="{space_key}"')
+        cql_query = " AND ".join(cql_parts)
+        cql_query = f"{cql_query} ORDER BY lastmodified DESC"
+        params = {"cql": cql_query, "limit": limit}
         headers = {"Accept": "application/json"}
         response = requests.get(
             url,


### PR DESCRIPTION
## Summary
- add an optional Confluence space key parameter to the search pages tool configuration and schema
- plumb the optional space key through the search tool and Confluence client, updating the CQL to include ordering

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df8a67f5d08327a93dd06cc0fa9615