### PR TITLE
Improve Jira issue creation error handling

### DIFF
--- a/python-agent-tools/create-issue/tool.py
+++ b/python-agent-tools/create-issue/tool.py
@@ -1,6 +1,6 @@
 from dataiku.llm.agent_tools import BaseAgentTool
 import logging
-from jira_client import JiraClient
+from jira_client import JiraClient, JiraIssueCreationError
 from utils import get_connection_details
 
 
@@ -17,7 +17,7 @@ class JiraCreateIssueTool(BaseAgentTool):
 
     def get_descriptor(self, tool):
         return {
-            "description": "This tool is a wrapper around atlassian-python-api\'s Jira issue_create API, useful when you need to create a Jira issue. The input to this tool is a dictionary containing the new issue summary and description, e.g. '{'summary':'new issue summary', 'description':'new issue description'}'",            
+            "description": "This tool is a wrapper around atlassian-python-api's Jira issue_create API, useful when you need to create a Jira issue. The input to this tool is a dictionary containing the new issue summary and description, e.g. '{'summary':'new issue summary', 'description':'new issue description'}'",
             "inputSchema": {
                 "$id": "https://dataiku.com/agents/tools/search/input",
                 "title": "Create Jira issue tool",
@@ -39,10 +39,41 @@ class JiraCreateIssueTool(BaseAgentTool):
     def create_jira_issue(self, summary: str, description: str, issue_type: str = "Task"):
         try:
             new_issue = self.client.create_issue(self.jira_project_key, summary, description, issue_type)
-            return new_issue
+            return {"success": True, "issue": new_issue}
+
+        except JiraIssueCreationError as exception:
+            error_messages = exception.error_messages or []
+            errors = exception.errors or {}
+
+            detailed_messages = []
+            if errors:
+                detailed_messages.extend(
+                    f"{field}: {message}" for field, message in errors.items() if message
+                )
+            if not detailed_messages and error_messages:
+                detailed_messages.extend(error_messages)
+            if not detailed_messages:
+                detailed_messages.append(str(exception))
+
+            human_message = "; ".join(detailed_messages)
+
+            return {
+                "success": False,
+                "error": {
+                    "message": human_message,
+                    "status_code": exception.status_code,
+                    "errorMessages": error_messages,
+                    "errors": errors,
+                }
+            }
 
         except Exception as exception:
-            return f"Error creating issue: {str(exception)}"
+            return {
+                "success": False,
+                "error": {
+                    "message": f"Error creating issue: {str(exception)}"
+                }
+            }
 
     def invoke(self, input, trace):
         args = input.get("input", {})
@@ -58,17 +89,24 @@ class JiraCreateIssueTool(BaseAgentTool):
         trace.attributes["config"] = {
             "jira_instance_url": jira_instance_url,
             "jira_project_key": self.jira_project_key
-        } 
+        }
 
-        created_issue = self.create_jira_issue(summary, description)
+        creation_result = self.create_jira_issue(summary, description)
 
-        if created_issue and "errors" in created_issue:
-            output_text = "There was a problem while creating the issue ticket: {}".format(
-                created_issue.get("errors", {}).get("description")
+        if creation_result.get("success"):
+            issue = creation_result.get("issue", {})
+            output_text = (
+                f"Issue created: {issue.get('key')} available at {jira_instance_url}browse/{issue.get('key')}"
             )
+            trace.outputs["issue"] = issue
         else:
-            output_text = f"Issue created: {created_issue.get('key')} available at {jira_instance_url}browse/{created_issue.get('key')}" if isinstance(created_issue, dict) else created_issue
-        
+            error_info = creation_result.get("error", {})
+            error_message = error_info.get("message", "Unknown error while creating the issue")
+            output_text = (
+                "There was a problem while creating the issue ticket: {}".format(error_message)
+            )
+            trace.outputs["error"] = error_info
+
         # Log outputs to trace
         trace.outputs["output"] = output_text
 

--- a/python-lib/jira_client.py
+++ b/python-lib/jira_client.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import json
 import os
+from typing import Any, Dict, List, Optional
 import jira_api as api
 from pagination import Pagination
 from utils import extract_data_with_json_path
@@ -13,6 +14,36 @@ FILTERING_KEY_WITH_PARAMETER = 1
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO,
                     format='jira plugin %(levelname)s - %(message)s')
+
+
+class JiraIssueCreationError(Exception):
+    """Custom exception for Jira issue creation failures."""
+
+    def __init__(self, status_code: int, error_messages: Optional[List[str]] = None,
+                 errors: Optional[Dict[str, Any]] = None, response_payload: Optional[Any] = None,
+                 response_text: str = ""):
+        self.status_code = status_code
+        self.error_messages = error_messages or []
+        self.errors = errors or {}
+        self.response_payload = response_payload
+        self.response_text = response_text
+
+        detailed_messages: List[str] = []
+        if self.errors:
+            detailed_messages.extend(
+                f"{field}: {message}" for field, message in self.errors.items() if message
+            )
+        if not detailed_messages and self.error_messages:
+            detailed_messages.extend(self.error_messages)
+        if not detailed_messages and isinstance(self.response_payload, dict) and self.response_payload:
+            detailed_messages.append(json.dumps(self.response_payload))
+        if not detailed_messages and self.response_text:
+            detailed_messages.append(self.response_text)
+        if not detailed_messages:
+            detailed_messages.append(f"Jira issue creation failed with status {self.status_code}")
+
+        message = "; ".join(detailed_messages)
+        super().__init__(message)
 
 
 class JiraClient(object):
@@ -236,8 +267,27 @@ class JiraClient(object):
         # This data form does not work on v3
         url = "/".join([self.get_site_url(), "rest/api/2/issue"])
         response = self.post(url=url, json=json)
-        json_response = response.json()
-        return json_response
+        response_payload = None
+        try:
+            response_payload = response.json()
+        except Exception:
+            response_payload = None
+
+        if response.status_code >= 400:
+            error_messages: List[str] = []
+            errors: Dict[str, Any] = {}
+            if isinstance(response_payload, dict):
+                error_messages = response_payload.get(api.API_ERROR_MESSAGES, []) or []
+                errors = response_payload.get("errors", {}) or {}
+            raise JiraIssueCreationError(
+                status_code=response.status_code,
+                error_messages=error_messages,
+                errors=errors,
+                response_payload=response_payload,
+                response_text=response.text,
+            )
+
+        return response_payload
 
     def get_auth(self):
         if self.is_opsgenie_api():

--- a/tests/python/unit/test_create_issue_tool.py
+++ b/tests/python/unit/test_create_issue_tool.py
@@ -1,0 +1,111 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+# Ensure plugin modules can be imported during tests
+ROOT_DIR = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT_DIR / "python-lib"))
+sys.path.append(str(ROOT_DIR / "python-agent-tools" / "create-issue"))
+
+
+# Provide a minimal stub for the Dataiku BaseAgentTool dependency
+if "dataiku" not in sys.modules:
+    dataiku_module = types.ModuleType("dataiku")
+    llm_module = types.ModuleType("dataiku.llm")
+    agent_tools_module = types.ModuleType("dataiku.llm.agent_tools")
+
+    class _BaseAgentTool:  # pragma: no cover - trivial stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+    agent_tools_module.BaseAgentTool = _BaseAgentTool
+    llm_module.agent_tools = agent_tools_module
+    dataiku_module.llm = llm_module
+
+    sys.modules["dataiku"] = dataiku_module
+    sys.modules["dataiku.llm"] = llm_module
+    sys.modules["dataiku.llm.agent_tools"] = agent_tools_module
+
+if "requests" not in sys.modules:
+    requests_module = types.ModuleType("requests")
+
+    def _request_stub(*args, **kwargs):  # pragma: no cover - safety stub
+        raise NotImplementedError("The requests module is not available in the test environment.")
+
+    requests_module.get = _request_stub
+    requests_module.post = _request_stub
+    sys.modules["requests"] = requests_module
+
+if "numpy" not in sys.modules:
+    numpy_module = types.ModuleType("numpy")
+    numpy_module.float64 = float
+    numpy_module.nan = float("nan")
+    sys.modules["numpy"] = numpy_module
+
+import jira_client
+from jira_client import JiraClient, JiraIssueCreationError
+from tool import JiraCreateIssueTool
+
+
+class DummyTrace:
+    def __init__(self):
+        self.span = {}
+        self.inputs = {}
+        self.outputs = {}
+        self.attributes = {}
+
+
+class DummyResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = "Response text"
+
+    def json(self):
+        return self._payload
+
+
+def test_create_issue_raises_error_with_error_messages(monkeypatch):
+    client = JiraClient({
+        "subdomain": "example",
+        "username": "user",
+        "token": "token",
+        "server_type": "cloud"
+    })
+
+    def fake_post(self, url, data=None, json=None, params=None):
+        return DummyResponse(400, {"errorMessages": ["Summary is required."]})
+
+    monkeypatch.setattr(JiraClient, "post", fake_post, raising=False)
+
+    with pytest.raises(JiraIssueCreationError) as excinfo:
+        client.create_issue("TEST", "", "A description", "Task")
+
+    assert excinfo.value.error_messages == ["Summary is required."]
+    assert excinfo.value.errors == {}
+
+
+def test_tool_invoke_surfaces_error_messages():
+    class DummyClient:
+        def __init__(self):
+            self._site_url = "https://example.atlassian.net/"
+
+        def create_issue(self, project_key, summary, description, issue_type):
+            raise JiraIssueCreationError(400, error_messages=["Summary is required."])
+
+        def get_site_url(self):
+            return self._site_url
+
+    tool_instance = JiraCreateIssueTool()
+    tool_instance.client = DummyClient()
+    tool_instance.jira_project_key = "TEST"
+
+    trace = DummyTrace()
+
+    result = tool_instance.invoke({"input": {"summary": "", "description": "Missing summary"}}, trace)
+
+    assert "Summary is required." in result["output"]
+    assert trace.outputs["error"]["message"] == "Summary is required."


### PR DESCRIPTION
## Summary
- raise a structured JiraIssueCreationError when issue creation responses include errors
- update the Jira create issue agent tool to surface detailed error messages in outputs and traces
- add unit tests covering Jira error propagation when only errorMessages are returned

## Testing
- pytest tests/python/unit -q

------
https://chatgpt.com/codex/tasks/task_e_68df94f4a11883279e2ff226bacf3cb6