### PR TITLE
Add configurable limit for Confluence search tool

### DIFF
--- a/python-agent-tools/search-confluence-pages/tool.json
+++ b/python-agent-tools/search-confluence-pages/tool.json
@@ -29,6 +29,14 @@
             "type": "STRING",
             "description": "Optional key of the Confluence space to restrict the search. Leave empty to search all spaces.",
             "optional": true
+        },
+        {
+            "name": "limit",
+            "label": "Documents limit",
+            "type": "STRING",
+            "description": "Maximum number of Confluence pages to return (default: 3).",
+            "defaultValue": "3",
+            "optional": true
         }
     ]
 }

--- a/python-agent-tools/search-confluence-pages/tool.py
+++ b/python-agent-tools/search-confluence-pages/tool.py
@@ -18,8 +18,8 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
         return {
             "description": (
                 "This tool searches Confluence pages using the provided keywords "
-                "and returns up to three results with their URLs, titles, and page "
-                "content."
+                "and returns up to the requested number of results with their URLs, "
+                "titles, and page content."
             ),
             "inputSchema": {
                 "$id": "https://dataiku.com/agents/tools/search/input",
@@ -84,7 +84,9 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
 
         search_result = self.search_pages(query, space_key, limit_value)
 
+        raw_results = []
         if isinstance(search_result, dict):
+            raw_results = search_result.get("results") or []
             trace.attributes["search"] = {
                 "source": search_result.get("source"),
                 "attempts": search_result.get("attempts"),
@@ -94,7 +96,7 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
 
         if isinstance(search_result, dict) and raw_results:
             items = []
-            for item in search_result.get("results", [])[:limit_value]:
+            for item in raw_results[:limit_value]:
                 title = item.get("title") or "Untitled"
                 page_id = item.get("id") or None
                 link = item.get("url")

--- a/python-lib/confluence_client.py
+++ b/python-lib/confluence_client.py
@@ -190,9 +190,10 @@ class ConfluenceClient(object):
         return payload
 
     def _build_v1_params(self, query: str, limit: int, space_key: Optional[str]) -> Dict[str, Any]:
-        cql_parts = [f'text~"{query}"']
+        cql_parts = []
         if space_key:
             cql_parts.append(f'space="{space_key}"')
+        cql_parts.append(f'text~"{query}"')
         cql_query = " AND ".join(cql_parts)
         cql_query = f"{cql_query} ORDER BY lastmodified DESC"
         return {"cql": cql_query, "limit": limit}

--- a/tests/python/unit/test_confluence_search_tool.py
+++ b/tests/python/unit/test_confluence_search_tool.py
@@ -144,7 +144,11 @@ def test_confluence_client_falls_back_to_v1(monkeypatch):
     def fake_post(url, json=None, auth=None, headers=None, verify=None):
         return DummyResponse(404, {"message": "not found"}, text="not found")
 
+    captured = {}
+
     def fake_get(url, params=None, auth=None, headers=None, verify=None):
+        captured["url"] = url
+        captured["params"] = params
         return DummyResponse(
             200,
             {
@@ -170,6 +174,8 @@ def test_confluence_client_falls_back_to_v1(monkeypatch):
     assert result["source"] == "v1"
     assert len(result["attempts"]) == 3
     assert result["attempts"][-1]["version"] == "v1"
+    assert captured["params"]["limit"] == 1
+    assert captured["params"]["cql"].startswith('space="SPACE" AND text~"legacy"')
     assert result["results"][0]["space_key"] == "SPACE"
     assert result["results"][0]["url"].endswith("/display/SPACE/Legacy+Page")
 


### PR DESCRIPTION
## Summary
- add a configurable "Documents limit" parameter to the Confluence search tool UI and descriptor
- update the search tool logic to honour the limit and avoid referencing undefined result variables
- ensure the v1 CQL query scopes space filtering within the query and cover the behaviour with unit tests

## Testing
- pytest tests/python/unit/test_confluence_search_tool.py

------
https://chatgpt.com/codex/tasks/task_e_68e3ac1a79d0832795b2f809b39e1792