### PR TITLE
Fix Confluence on-prem search fallback

### DIFF
--- a/python-agent-tools/search-confluence-pages/tool.json
+++ b/python-agent-tools/search-confluence-pages/tool.json
@@ -3,7 +3,7 @@
     "meta": {
         "icon": "icon-search",
         "label": "Search Confluence Pages",
-        "description": "Search Confluence pages by keywords and return the first three results"
+        "description": "Search Confluence pages by keywords and return up to the configured number of results (default: 3)"
     },
     "params": [
         {
@@ -28,6 +28,14 @@
             "label": "Confluence space key",
             "type": "STRING",
             "description": "Optional key of the Confluence space to restrict the search. Leave empty to search all spaces.",
+            "optional": true
+        },
+        {
+            "name": "limit",
+            "label": "Documents limit",
+            "type": "STRING",
+            "description": "Maximum number of Confluence pages to return (default: 3).",
+            "defaultValue": "3",
             "optional": true
         }
     ]

--- a/python-agent-tools/search-confluence-pages/tool.py
+++ b/python-agent-tools/search-confluence-pages/tool.py
@@ -1,7 +1,9 @@
-from dataiku.llm.agent_tools import BaseAgentTool
 import json
 import logging
 from urllib.parse import urljoin
+
+from dataiku.llm.agent_tools import BaseAgentTool
+
 from utils import get_connection_details
 from confluence_client import ConfluenceClient
 
@@ -18,8 +20,8 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
         return {
             "description": (
                 "This tool searches Confluence pages using the provided keywords "
-                "and returns up to three results with their URLs, titles, and page "
-                "content."
+                "and returns up to the requested number of results with their URLs, "
+                "titles, and page content."
             ),
             "inputSchema": {
                 "$id": "https://dataiku.com/agents/tools/search/input",
@@ -45,6 +47,23 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
             },
         }
 
+    @staticmethod
+    def _sanitize_limit(value, default: int = 3) -> int:
+        try:
+            limit_value = int(value)
+        except (TypeError, ValueError):
+            return default
+        return limit_value if limit_value > 0 else default
+
+    def _normalize_space_key(self, space_key):
+        if isinstance(space_key, str):
+            stripped = space_key.strip()
+            return stripped or None
+        if space_key is None:
+            return None
+        text_value = str(space_key).strip()
+        return text_value or None
+
     def search_pages(self, query: str, space_key: str = None, limit: int = 3):
         try:
             return self.client.search_pages(query, limit=limit, space_key=space_key)
@@ -57,16 +76,17 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
             }
 
     def invoke(self, input, trace):
-        args = input.get("input", {})
-        query = args.get("query")
-        space_key = args.get("space_key") or None
-        limit = args.get("limit", 3)
-        try:
-            limit_value = int(limit)
-        except (TypeError, ValueError):
-            limit_value = 3
-        if limit_value <= 0:
-            limit_value = 3
+        args = dict(input.get("input", {}))
+        query_value = args.get("query", "")
+        if isinstance(query_value, str):
+            query = query_value.strip()
+        elif query_value is None:
+            query = ""
+        else:
+            query = str(query_value)
+        space_key = self._normalize_space_key(args.get("space_key"))
+        limit_value = self._sanitize_limit(args.get("limit", 3))
+
         confluence_instance_url = self.client.site_url or ""
         base_url = (
             f"{confluence_instance_url.rstrip('/')}/"
@@ -75,8 +95,12 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
         )
 
         trace.span["name"] = "CONFLUENCE_SEARCH_PAGES_TOOL_CALL"
-        for key, value in args.items():
-            trace.inputs[key] = value
+        trace_inputs = {
+            "query": query,
+            "limit": limit_value,
+            "space_key": space_key,
+        }
+        trace.inputs.update(trace_inputs)
         trace.attributes["config"] = {
             "confluence_instance_url": confluence_instance_url,
             "limit": limit_value,
@@ -84,7 +108,9 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
 
         search_result = self.search_pages(query, space_key, limit_value)
 
+        raw_results = []
         if isinstance(search_result, dict):
+            raw_results = search_result.get("results") or []
             trace.attributes["search"] = {
                 "source": search_result.get("source"),
                 "attempts": search_result.get("attempts"),
@@ -94,7 +120,7 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
 
         if isinstance(search_result, dict) and raw_results:
             items = []
-            for item in search_result.get("results", [])[:limit_value]:
+            for item in raw_results[:limit_value]:
                 title = item.get("title") or "Untitled"
                 page_id = item.get("id") or None
                 link = item.get("url")

--- a/python-lib/confluence_client.py
+++ b/python-lib/confluence_client.py
@@ -116,8 +116,12 @@ class ConfluenceClient(object):
 
             if version == "v2" and response.status_code in {404, 405}:
                 attempt_record["error"] = "search endpoint unavailable"
+                self._search_v2_supported = False
                 attempts.append(attempt_record)
                 continue
+
+            if version == "v2" and response.status_code < 400:
+                self._search_v2_supported = True
 
             if response.status_code >= 400:
                 error_payload = self._safe_json(response)
@@ -177,42 +181,91 @@ class ConfluenceClient(object):
             return 3
         return parsed if parsed > 0 else 3
 
+    @staticmethod
+    def _normalize_query(query: Any) -> str:
+        if query is None:
+            return ""
+        if isinstance(query, str):
+            return query.strip()
+        return str(query)
+
+    @staticmethod
+    def _normalize_space_key(space_key: Optional[str]) -> Optional[str]:
+        if space_key is None:
+            return None
+        if isinstance(space_key, str):
+            stripped = space_key.strip()
+            return stripped or None
+        text = str(space_key).strip()
+        return text or None
+
+    @staticmethod
+    def _escape_cql_value(value: Any) -> str:
+        if value is None:
+            return ""
+        text = str(value)
+        text = text.replace("\\", "\\\\")
+        text = text.replace('"', '\\"')
+        return text
+
     def _build_v2_payload(self, query: str, limit: int, space_key: Optional[str]) -> Dict[str, Any]:
-        query_string = f'text ~ "{query}"'
+        normalized_query = self._normalize_query(query)
+        escaped_query = self._escape_cql_value(normalized_query)
+        query_string = f'text ~ "{escaped_query}"'
         payload: Dict[str, Any] = {
             "queryString": query_string,
             "entityType": ["page"],
             "limit": limit,
             "sort": "modified_date DESC",
         }
-        if space_key:
-            payload["spaceKeys"] = [space_key]
+        normalized_space = self._normalize_space_key(space_key)
+        if normalized_space:
+            payload["spaceKeys"] = [normalized_space]
         return payload
 
     def _build_v1_params(self, query: str, limit: int, space_key: Optional[str]) -> Dict[str, Any]:
-        cql_parts = [f'text~"{query}"']
-        if space_key:
-            cql_parts.append(f'space="{space_key}"')
-        cql_query = " AND ".join(cql_parts)
-        cql_query = f"{cql_query} ORDER BY lastmodified DESC"
+        normalized_space = self._normalize_space_key(space_key)
+        cql_query = self._compose_v1_cql_query(query=query, space_key=normalized_space)
         return {"cql": cql_query, "limit": limit}
+
+    def _compose_v1_cql_query(self, query: str, space_key: Optional[str]) -> str:
+        """Build the Confluence Query Language string for v1 searches.
+
+        Space scoping is embedded directly in the CQL so that on-premises
+        instances honour the restriction instead of relying on a separate
+        ``space`` query parameter, which the endpoint ignores.
+        """
+
+        cql_parts = []
+        normalized_space = self._normalize_space_key(space_key)
+        if normalized_space:
+            escaped_space = self._escape_cql_value(normalized_space)
+            cql_parts.append(f'space="{escaped_space}"')
+        normalized_query = self._normalize_query(query)
+        escaped_query = self._escape_cql_value(normalized_query)
+        cql_parts.append(f'text~"{escaped_query}"')
+        cql_query = " AND ".join(cql_parts)
+        return f"{cql_query} ORDER BY lastmodified DESC"
 
     def _search_endpoint_candidates(self) -> List[Dict[str, str]]:
         base_url = self.site_url
         candidates: List[Dict[str, str]] = []
 
-        # Primary v2 endpoint relative to the configured site URL.
-        v2_primary = urljoin(base_url, "api/v2/search")
-        candidates.append({"version": "v2", "method": "POST", "url": v2_primary})
+        prefer_v2 = self.server_type == "cloud" and self._search_v2_supported is not False
 
-        # Some on-prem instances expose v2 under /wiki/api/v2/ even when the
-        # configured base URL does not include /wiki/.
-        v2_alt = urljoin(base_url, "wiki/api/v2/search")
-        if v2_alt != v2_primary:
-            candidates.append({"version": "v2", "method": "POST", "url": v2_alt})
+        if prefer_v2:
+            # Primary v2 endpoint relative to the configured site URL.
+            v2_primary = urljoin(base_url, "api/v2/search")
+            candidates.append({"version": "v2", "method": "POST", "url": v2_primary})
+
+            # Some instances expose v2 under /wiki/api/v2/ even when the base URL
+            # does not include /wiki/.
+            v2_alt = urljoin(base_url, "wiki/api/v2/search")
+            if v2_alt != v2_primary:
+                candidates.append({"version": "v2", "method": "POST", "url": v2_alt})
 
         # Legacy v1 endpoint fallback.
-        v1_url = urljoin(base_url, "rest/api/search")
+        v1_url = urljoin(base_url, "rest/api/content/search")
         candidates.append({"version": "v1", "method": "GET", "url": v1_url})
 
         return candidates

--- a/tests/python/unit/test_confluence_search_tool.py
+++ b/tests/python/unit/test_confluence_search_tool.py
@@ -131,7 +131,7 @@ def test_confluence_client_prefers_v2(monkeypatch):
     assert result["results"][0]["url"].endswith("/wiki/spaces/SPACE/pages/123/Demo+Page")
 
 
-def test_confluence_client_falls_back_to_v1(monkeypatch):
+def test_confluence_client_uses_v1_on_on_prem(monkeypatch):
     client = ConfluenceClient(
         {
             "server_type": "on_premise",
@@ -141,10 +141,67 @@ def test_confluence_client_falls_back_to_v1(monkeypatch):
         }
     )
 
-    def fake_post(url, json=None, auth=None, headers=None, verify=None):
-        return DummyResponse(404, {"message": "not found"}, text="not found")
+    captured = {}
+
+    def fake_post(*args, **kwargs):  # pragma: no cover - defensive guard
+        raise AssertionError("v2 search should not be attempted for on-prem instances")
 
     def fake_get(url, params=None, auth=None, headers=None, verify=None):
+        captured["url"] = url
+        captured["params"] = params
+        return DummyResponse(
+            200,
+            {
+                "results": [
+                    {
+                        "content": {
+                            "id": "456",
+                            "title": "Legacy Page",
+                            "_links": {"webui": "/display/SPACE/Legacy+Page"},
+                            "space": {"key": "SPACE"},
+                        },
+                        "excerpt": "Legacy excerpt",
+                    }
+                ]
+            },
+    )
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    result = client.search_pages("legacy", limit=1, space_key="SPACE")
+
+    assert result["source"] == "v1"
+    assert len(result["attempts"]) == 1
+    assert result["attempts"][0]["version"] == "v1"
+    assert captured["params"]["limit"] == 1
+    assert captured["params"]["cql"].startswith('space="SPACE" AND text~"legacy"')
+    assert captured["url"].endswith("/rest/api/content/search")
+    assert result["results"][0]["space_key"] == "SPACE"
+    assert result["results"][0]["url"].endswith("/display/SPACE/Legacy+Page")
+
+
+def test_confluence_client_caches_missing_v2(monkeypatch):
+    client = ConfluenceClient(
+        {
+            "server_type": "cloud",
+            "subdomain": "example",
+            "username": "user",
+            "token": "token",
+        }
+    )
+
+    post_calls = {"count": 0}
+
+    def fake_post(url, json=None, auth=None, headers=None, verify=None):
+        post_calls["count"] += 1
+        return DummyResponse(404, {"message": "not found"}, text="not found")
+
+    captured = {}
+
+    def fake_get(url, params=None, auth=None, headers=None, verify=None):
+        captured.setdefault("urls", []).append(url)
+        captured["params"] = params
         return DummyResponse(
             200,
             {
@@ -165,13 +222,54 @@ def test_confluence_client_falls_back_to_v1(monkeypatch):
     monkeypatch.setattr(requests, "post", fake_post)
     monkeypatch.setattr(requests, "get", fake_get)
 
-    result = client.search_pages("legacy", limit=1, space_key="SPACE")
+    first_result = client.search_pages("legacy", limit=1, space_key="SPACE")
 
-    assert result["source"] == "v1"
-    assert len(result["attempts"]) == 3
-    assert result["attempts"][-1]["version"] == "v1"
-    assert result["results"][0]["space_key"] == "SPACE"
-    assert result["results"][0]["url"].endswith("/display/SPACE/Legacy+Page")
+    assert first_result["source"] == "v1"
+    assert len(first_result["attempts"]) == 3
+    assert post_calls["count"] == 2
+
+    def fail_post(*args, **kwargs):  # pragma: no cover - safety guard
+        raise AssertionError("v2 should be skipped after prior 404 responses")
+
+    monkeypatch.setattr(requests, "post", fail_post)
+
+    second_result = client.search_pages("legacy", limit=1, space_key="SPACE")
+
+    assert second_result["source"] == "v1"
+    assert len(second_result["attempts"]) == 1
+    assert captured["urls"][-1].endswith("/rest/api/content/search")
+
+
+def test_compose_v1_cql_query_scopes_space():
+    client = ConfluenceClient(
+        {
+            "server_type": "on_premise",
+            "api_url": "https://confluence.example.com/",
+            "username": "user",
+            "token": "token",
+        }
+    )
+
+    cql = client._compose_v1_cql_query(query="Dataiku", space_key="AIEC")
+
+    assert cql.startswith('space="AIEC" AND text~"Dataiku"')
+    assert cql.endswith("ORDER BY lastmodified DESC")
+
+
+def test_sanitize_limit_defaults_when_invalid():
+    client = ConfluenceClient(
+        {
+            "server_type": "cloud",
+            "subdomain": "example",
+            "username": "user",
+            "token": "token",
+        }
+    )
+
+    assert client._sanitize_limit("not-a-number") == 3
+    assert client._sanitize_limit(None) == 3
+    assert client._sanitize_limit(-10) == 3
+    assert client._sanitize_limit(5) == 5
 
 
 def test_confluence_client_reports_error(monkeypatch):
@@ -248,6 +346,9 @@ def test_tool_invoke_formats_results_and_trace(monkeypatch):
     )
 
     assert trace.attributes["config"]["limit"] == 1
+    assert trace.inputs["query"] == "tool"
+    assert trace.inputs["limit"] == 1
+    assert trace.inputs["space_key"] == "SPACE"
     assert trace.attributes["search"]["source"] == "v2"
     assert trace.attributes["search"]["space_key"] == "SPACE"
     assert len(result["results"]) == 1
@@ -256,3 +357,88 @@ def test_tool_invoke_formats_results_and_trace(monkeypatch):
     assert "Tool excerpt" in item["excerpt"]
     assert item["page_content"] == "<p>Content for 789</p>"
     assert trace.outputs["results"] == result["results"]
+
+
+
+def test_compose_v1_cql_query_escapes_special_characters():
+    client = ConfluenceClient(
+        {
+            "server_type": "on_premise",
+            "api_url": "https://confluence.example.com/",
+            "username": "user",
+            "token": "token",
+        }
+    )
+
+    raw_query = 'Data "iku" \\ story'
+    raw_space = ' A"IEC '
+    cql = client._compose_v1_cql_query(
+        query=raw_query,
+        space_key=raw_space,
+    )
+
+    expected_space = raw_space.strip().replace("\\", "\\\\").replace('"', '\\"')
+    expected_query = raw_query.strip().replace("\\", "\\\\").replace('"', '\\"')
+
+    assert f'space="{expected_space}"' in cql
+    assert f'text~"{expected_query}"' in cql
+    assert cql.endswith('ORDER BY lastmodified DESC')
+
+
+def test_build_v2_payload_normalizes_inputs():
+    client = ConfluenceClient(
+        {
+            "server_type": "cloud",
+            "subdomain": "example",
+            "username": "user",
+            "token": "token",
+        }
+    )
+
+    raw_query = '  Demo  "story"  '
+    payload = client._build_v2_payload(
+        query=raw_query,
+        limit=5,
+        space_key=' SPACE ',
+    )
+
+    expected_query = raw_query.strip().replace("\\", "\\\\").replace('"', '\\"')
+
+    assert payload["queryString"] == f'text ~ "{expected_query}"'
+    assert payload["limit"] == 5
+    assert payload["spaceKeys"] == ["SPACE"]
+
+
+
+def test_tool_invoke_sanitizes_inputs():
+    tool_instance = ConfluenceSearchPagesTool()
+
+    captured = {}
+
+    class DummyClient:
+        site_url = "https://confluence.example.com/"
+
+        def search_pages(self, query, limit=3, space_key=None):
+            captured["query"] = query
+            captured["limit"] = limit
+            captured["space_key"] = space_key
+            return {"results": [], "source": "v1", "attempts": []}
+
+    tool_instance.client = DummyClient()
+
+    trace = DummyTrace()
+
+    result = tool_instance.invoke(
+        {"input": {"query": "  trimmed  ", "space_key": "   ", "limit": "invalid"}},
+        trace,
+    )
+
+    assert captured == {"query": "trimmed", "limit": 3, "space_key": None}
+    assert trace.inputs["query"] == "trimmed"
+    assert trace.inputs["limit"] == 3
+    assert trace.inputs["space_key"] is None
+    assert trace.attributes["config"]["limit"] == 3
+    assert trace.attributes["search"]["source"] == "v1"
+    assert trace.attributes["search"]["space_key"] is None
+    assert result["results"] == []
+    assert result["output"] == "No Confluence pages matched your query."


### PR DESCRIPTION
## Summary
- stop attempting REST API v2 endpoints for on-prem Confluence connections and correct the v1 search URL
- cache missing v2 endpoints after a 404/405 so subsequent searches immediately use v1
- extend the unit suite with coverage for on-prem-only searches and the v2 caching behaviour

## Testing
- pytest tests/python/unit/test_confluence_search_tool.py

------
https://chatgpt.com/codex/tasks/task_e_68e3ac1a79d0832795b2f809b39e1792