### PR TITLE
Fix on-prem Confluence search defaults and endpoint

### DIFF
--- a/python-agent-tools/search-confluence-pages/tool.json
+++ b/python-agent-tools/search-confluence-pages/tool.json
@@ -3,7 +3,7 @@
     "meta": {
         "icon": "icon-search",
         "label": "Search Confluence Pages",
-        "description": "Search Confluence pages by keywords and return the first three results"
+        "description": "Search Confluence pages by keywords and return up to the configured number of results (default: 3)"
     },
     "params": [
         {
@@ -28,6 +28,14 @@
             "label": "Confluence space key",
             "type": "STRING",
             "description": "Optional key of the Confluence space to restrict the search. Leave empty to search all spaces.",
+            "optional": true
+        },
+        {
+            "name": "limit",
+            "label": "Documents limit",
+            "type": "STRING",
+            "description": "Maximum number of Confluence pages to return (default: 3).",
+            "defaultValue": "3",
             "optional": true
         }
     ]

--- a/python-agent-tools/search-confluence-pages/tool.py
+++ b/python-agent-tools/search-confluence-pages/tool.py
@@ -1,14 +1,16 @@
-from dataiku.llm.agent_tools import BaseAgentTool
 import json
 import logging
 from urllib.parse import urljoin
+
+from dataiku.llm.agent_tools import BaseAgentTool
+
 from utils import get_connection_details
 from confluence_client import ConfluenceClient
 
 
 class ConfluenceSearchPagesTool(BaseAgentTool):
     def set_config(self, config, plugin_config):
-        logging.getLogger("jiraapiclient.discovery").setLevel("INFO")
+        logging.getLogger("confluence_client").setLevel("INFO")
         logging.info("ConfluenceSearchPagesTool init")
         self.config = config
         connection_details = get_connection_details(config)
@@ -18,8 +20,8 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
         return {
             "description": (
                 "This tool searches Confluence pages using the provided keywords "
-                "and returns up to three results with their URLs, titles, and page "
-                "content."
+                "and returns up to the requested number of results with their URLs, "
+                "titles, and page content."
             ),
             "inputSchema": {
                 "$id": "https://dataiku.com/agents/tools/search/input",
@@ -45,6 +47,23 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
             },
         }
 
+    @staticmethod
+    def _sanitize_limit(value, default: int = 3) -> int:
+        try:
+            limit_value = int(value)
+        except (TypeError, ValueError):
+            return default
+        return limit_value if limit_value > 0 else default
+
+    def _normalize_space_key(self, space_key):
+        if isinstance(space_key, str):
+            stripped = space_key.strip()
+            return stripped or None
+        if space_key is None:
+            return None
+        text_value = str(space_key).strip()
+        return text_value or None
+
     def search_pages(self, query: str, space_key: str = None, limit: int = 3):
         try:
             return self.client.search_pages(query, limit=limit, space_key=space_key)
@@ -57,16 +76,27 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
             }
 
     def invoke(self, input, trace):
-        args = input.get("input", {})
-        query = args.get("query")
-        space_key = args.get("space_key") or None
-        limit = args.get("limit", 3)
-        try:
-            limit_value = int(limit)
-        except (TypeError, ValueError):
-            limit_value = 3
-        if limit_value <= 0:
-            limit_value = 3
+        args = dict(input.get("input", {}))
+        config_defaults = getattr(self, "config", {}) or {}
+        query_value = args.get("query", "")
+        if isinstance(query_value, str):
+            query = query_value.strip()
+        elif query_value is None:
+            query = ""
+        else:
+            query = str(query_value)
+        if "space_key" in args:
+            space_source = args.get("space_key")
+        else:
+            space_source = config_defaults.get("space_key")
+        space_key = self._normalize_space_key(space_source)
+
+        if "limit" in args:
+            limit_source = args.get("limit")
+        else:
+            limit_source = config_defaults.get("limit", 3)
+        limit_value = self._sanitize_limit(limit_source)
+
         confluence_instance_url = self.client.site_url or ""
         base_url = (
             f"{confluence_instance_url.rstrip('/')}/"
@@ -75,16 +105,23 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
         )
 
         trace.span["name"] = "CONFLUENCE_SEARCH_PAGES_TOOL_CALL"
-        for key, value in args.items():
-            trace.inputs[key] = value
+        trace_inputs = {
+            "query": query,
+            "limit": limit_value,
+            "space_key": space_key,
+        }
+        trace.inputs.update(trace_inputs)
         trace.attributes["config"] = {
             "confluence_instance_url": confluence_instance_url,
             "limit": limit_value,
+            "space_key": space_key,
         }
 
         search_result = self.search_pages(query, space_key, limit_value)
 
+        raw_results = []
         if isinstance(search_result, dict):
+            raw_results = search_result.get("results") or []
             trace.attributes["search"] = {
                 "source": search_result.get("source"),
                 "attempts": search_result.get("attempts"),
@@ -94,7 +131,7 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
 
         if isinstance(search_result, dict) and raw_results:
             items = []
-            for item in search_result.get("results", [])[:limit_value]:
+            for item in raw_results[:limit_value]:
                 title = item.get("title") or "Untitled"
                 page_id = item.get("id") or None
                 link = item.get("url")
@@ -160,6 +197,9 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
             message = search_result.get("message")
             attempts = search_result.get("attempts", [])
             trace.attributes.setdefault("search", {})["attempts"] = attempts
+            error_info = search_result.get("error") if isinstance(search_result.get("error"), dict) else {}
+            if not message and error_info:
+                message = error_info.get("message")
             output_message = message or "No Confluence pages matched your query."
             trace.outputs["message"] = output_message
             trace.outputs["results"] = []

--- a/python-lib/confluence_client.py
+++ b/python-lib/confluence_client.py
@@ -1,242 +1,192 @@
 import logging
 from typing import Any, Dict, List, Optional
-from urllib.parse import urljoin
+from urllib.parse import urlencode, urljoin
 
 import requests
 
-from jira_client import normalize_url
 
 logger = logging.getLogger(__name__)
 
 
-class ConfluenceClient(object):
-    CONFLUENCE_SITE_URL = "https://{subdomain}.atlassian.net/wiki"
+class ConfluenceClient:
+    """Lightweight Confluence REST API helper focused on search."""
 
-    def __init__(self, connection_details):
+    def __init__(self, connection_details: Dict[str, Any]):
         logger.info("ConfluenceClient init")
+
         self.server_type = connection_details.get("server_type", "cloud")
-        self.subdomain = connection_details.get("subdomain")
-        self.api_url = normalize_url(connection_details.get("api_url", ""))
-        self.username = connection_details.get("username", "")
-        self.password = connection_details.get("token", "")
-        self.ignore_ssl_check = connection_details.get("ignore_ssl_check", False)
-        self.site_url = self.get_site_url()
-        # Track whether the v2 search endpoint is available to avoid retrying
-        # known-missing URLs on every invocation. The value remains ``None``
-        # until we successfully call v2 (True) or receive a definitive 404/405
-        # (False).
-        self._search_v2_supported: Optional[bool] = None
+        subdomain = connection_details.get("subdomain")
+        api_url = (connection_details.get("api_url") or "").rstrip("/")
 
-    def get_site_url(self):
-        if self.server_type == "cloud":
-            return normalize_url(self.CONFLUENCE_SITE_URL.format(subdomain=self.subdomain))
+        if self.server_type == "cloud" and subdomain:
+            base_url = f"https://{subdomain}.atlassian.net/wiki"
         else:
-            return normalize_url(self.api_url)
+            base_url = api_url
 
-    def create_page(self, title, content, space_key):
-        url = f"{self.site_url}rest/api/content"
-        data = {
-            "type": "page",
-            "title": title,
-            "space": {"key": space_key},
-            "body": {
-                "storage": {"value": content, "representation": "storage"}
-            },
+        self.base_url = base_url.rstrip("/")
+        self.site_url = f"{self.base_url}/" if self.base_url else ""
+        self.verify = not connection_details.get("ignore_ssl_check", False)
+
+        self.session = requests.Session()
+        self.session.headers.update({"Accept": "application/json"})
+        self.session.verify = self.verify
+
+        username = connection_details.get("username")
+        password = connection_details.get("password")
+        token = connection_details.get("token")
+
+        if username and (password or token):
+            self.session.auth = (username, password or token)
+        elif token:
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
+
+    # ------------------------------------------------------------------
+    # REST helpers
+    # ------------------------------------------------------------------
+    def _request(self, method: str, url: str, **kwargs) -> requests.Response:
+        kwargs.setdefault("timeout", 30)
+        return self.session.request(method, url, **kwargs)
+
+    @staticmethod
+    def _escape_cql_value(value: Any) -> str:
+        if value is None:
+            return ""
+        text = str(value)
+        # Newlines in CQL fragments can break parsing, normalise them to spaces
+        text = text.replace("\r", " ").replace("\n", " ")
+        replacements = {
+            "\\": "\\\\",
+            '"': '\\"',
         }
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
-        response = requests.post(
-            url,
-            json=data,
-            auth=(self.username, self.password),
-            headers=headers,
-            verify=not self.ignore_ssl_check,
-        )
-        return response.json()
+        for original, escaped in replacements.items():
+            text = text.replace(original, escaped)
+        return text
 
-    def search_pages(self, query, limit=3, space_key=None):
-        """Search Confluence pages preferring the REST API v2 endpoint.
+    @staticmethod
+    def _coerce_positive_int(value: Any, default: int = 3) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
 
-        Falls back to the legacy v1 search endpoint when v2 is unavailable
-        (e.g., older Confluence Data Center versions that return 404/405).
-        The response contains normalized result entries along with metadata
-        describing which endpoint succeeded and any intermediate errors.
-        """
+    def _normalise_space_key(self, space_key: Optional[str]) -> Optional[str]:
+        if space_key is None:
+            return None
+        if isinstance(space_key, str):
+            stripped = space_key.strip()
+            return stripped or None
+        return str(space_key).strip() or None
 
-        sanitized_limit = self._sanitize_limit(limit)
-        payload_v2 = self._build_v2_payload(query=query, limit=sanitized_limit, space_key=space_key)
-        cql_params = self._build_v1_params(query=query, limit=sanitized_limit, space_key=space_key)
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def search_pages(self, query: str, limit: int = 3, space_key: Optional[str] = None) -> Dict[str, Any]:
+        attempts: List[str] = []
 
-        attempts: List[Dict[str, Any]] = []
-        headers_v2 = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        }
-        headers_v1 = {"Accept": "application/json"}
+        limit_value = self._coerce_positive_int(limit, default=3)
 
-        for endpoint in self._search_endpoint_candidates():
-            version = endpoint["version"]
-            url = endpoint["url"]
-            method = endpoint["method"]
+        query_text = (query or "").strip()
+        if query_text.endswith("?"):
+            query_text = query_text[:-1].strip()
 
-            try:
-                if version == "v2":
-                    response = requests.post(
-                        url,
-                        json=payload_v2,
-                        auth=(self.username, self.password),
-                        headers=headers_v2,
-                        verify=not self.ignore_ssl_check,
-                    )
-                else:
-                    response = requests.get(
-                        url,
-                        params=cql_params,
-                        auth=(self.username, self.password),
-                        headers=headers_v1,
-                        verify=not self.ignore_ssl_check,
-                    )
-            except requests.RequestException as exc:  # pragma: no cover - network failure
-                attempts.append(
-                    {
-                        "version": version,
-                        "method": method,
-                        "url": url,
-                        "status_code": None,
-                        "error": str(exc),
-                    }
-                )
-                continue
+        cql_parts = ["type=page"]
 
-            attempt_record = {
-                "version": version,
-                "method": method,
-                "url": url,
-                "status_code": response.status_code,
-            }
+        normalised_space = self._normalise_space_key(space_key)
+        if normalised_space:
+            escaped_space = self._escape_cql_value(normalised_space)
+            cql_parts.append(f'space = "{escaped_space}"')
 
-            if version == "v2" and response.status_code in {404, 405}:
-                attempt_record["error"] = "search endpoint unavailable"
-                attempts.append(attempt_record)
-                continue
+        if query_text:
+            escaped_query = self._escape_cql_value(query_text)
+            cql_parts.append(f'text ~ "{escaped_query}"')
 
-            if response.status_code >= 400:
-                error_payload = self._safe_json(response)
-                attempt_record["error"] = self._extract_error_message(error_payload, response.text)
-                attempts.append(attempt_record)
-                return {
-                    "results": [],
-                    "error": {
-                        "message": attempt_record["error"],
-                        "status_code": response.status_code,
-                        "details": error_payload,
-                    },
-                    "attempts": attempts,
-                    "source": version,
-                }
+        cql = " AND ".join(cql_parts) + " ORDER BY lastmodified DESC"
+        attempts.append(f"CQL={cql}")
 
-            try:
-                payload = response.json()
-            except ValueError:
-                attempt_record["error"] = "invalid JSON response"
-                attempts.append(attempt_record)
-                return {
-                    "results": [],
-                    "error": {
-                        "message": "Unexpected response from Confluence search endpoint.",
-                        "status_code": response.status_code,
-                        "details": response.text,
-                    },
-                    "attempts": attempts,
-                    "source": version,
-                }
+        url = f"{self.base_url}/rest/api/search"
+        params = {"cql": cql, "limit": limit_value}
+        attempts.append(f"GET {url}?{urlencode(params)}")
 
-            attempts.append(attempt_record)
-            normalized_results = self._normalize_results(payload, version)
+        try:
+            response = self._request("GET", url, params=params)
+        except requests.RequestException as exc:  # pragma: no cover - network failure
+            message = f"Request failed: {exc}"
             return {
-                "results": normalized_results,
-                "raw": payload,
+                "results": [],
+                "error": {"message": message},
+                "source": "confluence",
                 "attempts": attempts,
-                "source": version,
+                "message": message,
             }
+
+        if not response.ok:
+            message = self._build_error_message(response)
+            return {
+                "results": [],
+                "error": {"message": message},
+                "source": "confluence",
+                "attempts": attempts,
+                "message": message,
+            }
+
+        try:
+            payload = response.json() if response.content else {}
+        except ValueError:
+            message = "Unable to decode Confluence response as JSON."
+            return {
+                "results": [],
+                "error": {"message": message},
+                "source": "confluence",
+                "attempts": attempts,
+                "message": message,
+            }
+
+        results: List[Dict[str, Any]] = []
+        raw_entries = payload.get("results") or []
+        for index, entry in enumerate(raw_entries):
+            if isinstance(entry, dict):
+                results.append(self._normalise_result_entry(entry))
+            else:
+                attempts.append(f"Skipped non-dict search entry at index {index}")
 
         return {
-            "results": [],
-            "error": {
-                "message": "No supported Confluence search endpoint responded successfully.",
-                "status_code": None,
-                "details": attempts,
-            },
+            "results": results,
+            "source": "confluence",
             "attempts": attempts,
-            "source": None,
         }
 
-    def _sanitize_limit(self, limit: Optional[int]) -> int:
+    def get_page_content(self, page_id: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/rest/api/content/{page_id}"
+        params = {"expand": "body.storage"}
+
         try:
-            parsed = int(limit)
-        except (TypeError, ValueError):
-            return 3
-        return parsed if parsed > 0 else 3
+            response = self._request("GET", url, params=params)
+        except requests.RequestException as exc:  # pragma: no cover - network failure
+            return {"error": {"message": f"Request failed: {exc}"}}
 
-    def _build_v2_payload(self, query: str, limit: int, space_key: Optional[str]) -> Dict[str, Any]:
-        query_string = f'text ~ "{query}"'
-        payload: Dict[str, Any] = {
-            "queryString": query_string,
-            "entityType": ["page"],
-            "limit": limit,
-            "sort": "modified_date DESC",
-        }
-        if space_key:
-            payload["spaceKeys"] = [space_key]
-        return payload
+        if not response.ok:
+            return {"error": {"message": self._build_error_message(response)}}
 
-    def _build_v1_params(self, query: str, limit: int, space_key: Optional[str]) -> Dict[str, Any]:
-        cql_parts = [f'text~"{query}"']
-        if space_key:
-            cql_parts.append(f'space="{space_key}"')
-        cql_query = " AND ".join(cql_parts)
-        cql_query = f"{cql_query} ORDER BY lastmodified DESC"
-        return {"cql": cql_query, "limit": limit}
+        try:
+            return response.json() if response.content else {}
+        except ValueError:
+            return {"error": {"message": "Unable to decode Confluence response as JSON."}}
 
-    def _search_endpoint_candidates(self) -> List[Dict[str, str]]:
-        base_url = self.site_url
-        candidates: List[Dict[str, str]] = []
+    # ------------------------------------------------------------------
+    # Normalisation helpers
+    # ------------------------------------------------------------------
+    def _normalise_result_entry(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+        content = entry.get("content") if isinstance(entry.get("content"), dict) else {}
 
-        # Primary v2 endpoint relative to the configured site URL.
-        v2_primary = urljoin(base_url, "api/v2/search")
-        candidates.append({"version": "v2", "method": "POST", "url": v2_primary})
-
-        # Some on-prem instances expose v2 under /wiki/api/v2/ even when the
-        # configured base URL does not include /wiki/.
-        v2_alt = urljoin(base_url, "wiki/api/v2/search")
-        if v2_alt != v2_primary:
-            candidates.append({"version": "v2", "method": "POST", "url": v2_alt})
-
-        # Legacy v1 endpoint fallback.
-        v1_url = urljoin(base_url, "rest/api/search")
-        candidates.append({"version": "v1", "method": "GET", "url": v1_url})
-
-        return candidates
-
-    def _normalize_results(self, payload: Dict[str, Any], version: str) -> List[Dict[str, Any]]:
-        results: List[Dict[str, Any]] = []
-        for entry in payload.get("results", []) or []:
-            normalized = self._normalize_entry(entry, version)
-            results.append(normalized)
-        return results
-
-    def _normalize_entry(self, entry: Dict[str, Any], version: str) -> Dict[str, Any]:
-        content = entry.get("content") if isinstance(entry, dict) else None
-        if not isinstance(content, dict):
-            content = {}
-
-        page_id = str(content.get("id") or entry.get("id") or "")
+        page_id = str(entry.get("id") or content.get("id") or "")
         title = content.get("title") or entry.get("title") or "Untitled"
 
-        links = {}
-        if isinstance(content.get("_links"), dict):
-            links.update(content["_links"])
+        links: Dict[str, Any] = {}
         if isinstance(entry.get("_links"), dict):
             links.update(entry["_links"])
+        if isinstance(content.get("_links"), dict):
+            links.update(content["_links"])
 
         link_path = (
             links.get("webui")
@@ -244,117 +194,90 @@ class ConfluenceClient(object):
             or links.get("self")
             or entry.get("url")
         )
-        full_url = self._build_full_url(link_path)
 
-        excerpt = entry.get("excerpt") or content.get("excerpt") or ""
+        absolute_url = None
+        if isinstance(link_path, str) and link_path.startswith("http"):
+            absolute_url = link_path
+        elif isinstance(link_path, str) and self.site_url:
+            absolute_url = urljoin(self.site_url, link_path.lstrip("/"))
+
+        excerpt = entry.get("excerpt") or entry.get("excerptText") or content.get("excerpt")
         last_modified = (
-            entry.get("modified")
-            or entry.get("lastModified")
+            entry.get("lastModified")
+            or entry.get("last_modified")
+            or entry.get("modified")
+            or content.get("lastModified")
             or content.get("lastModifiedDate")
-            or content.get("version", {}).get("when")
+            or (content.get("version", {}) if isinstance(content.get("version"), dict) else {}).get("when")
         )
 
         space_key = None
-        if isinstance(content.get("space"), dict):
-            space_key = content.get("space", {}).get("key")
-        if not space_key and isinstance(entry.get("space"), dict):
-            space_key = entry.get("space", {}).get("key")
+        if isinstance(entry.get("space"), dict):
+            space_key = entry["space"].get("key")
+        if not space_key and isinstance(content.get("space"), dict):
+            space_key = content["space"].get("key")
         if not space_key and isinstance(entry.get("spaceKey"), str):
             space_key = entry.get("spaceKey")
 
         return {
             "id": page_id,
             "title": title,
-            "url": full_url,
-            "url_path": link_path,
+            "url": absolute_url,
+            "url_path": link_path if isinstance(link_path, str) else None,
             "excerpt": excerpt,
             "last_modified": last_modified,
             "space_key": space_key,
-            "raw": entry,
-            "version": version,
         }
 
-    def _build_full_url(self, link_path: Optional[str]) -> Optional[str]:
-        if not link_path:
-            return None
-        if isinstance(link_path, str) and link_path.startswith("http"):
-            return link_path
+    def _build_error_message(self, response: requests.Response) -> str:
+        status = response.status_code
 
-        if not isinstance(link_path, str):
-            return None
-
-        base_url = self.site_url.rstrip("/") + "/"
-        normalized_path = link_path.lstrip("/")
-        return urljoin(base_url, normalized_path)
-
-    @staticmethod
-    def _safe_json(response) -> Optional[Any]:
+        detail: Optional[str] = None
         try:
-            return response.json()
+            payload = response.json()
         except ValueError:
-            return response.text
+            payload = None
 
-    @staticmethod
-    def _extract_error_message(payload: Any, fallback_text: str) -> str:
         if isinstance(payload, dict):
-            message = payload.get("message")
-            if message:
-                return message
-            if "errorMessage" in payload:
-                return payload["errorMessage"]
-            if "errorMessages" in payload and payload["errorMessages"]:
-                return "; ".join(payload["errorMessages"])
-            if "errors" in payload and isinstance(payload["errors"], dict):
-                parts = [
-                    f"{field}: {value}"
-                    for field, value in payload["errors"].items()
-                    if value
-                ]
-                if parts:
-                    return "; ".join(parts)
-        return fallback_text
+            detail = (
+                payload.get("message")
+                or payload.get("errorMessage")
+                or ("; ".join(payload.get("errorMessages", [])) if payload.get("errorMessages") else None)
+            )
 
-    def get_page_content(self, page_id):
-        url = f"{self.site_url}rest/api/content/{page_id}"
-        params = {"expand": "body.storage"}
-        headers = {"Accept": "application/json"}
-        response = requests.get(
-            url,
-            params=params,
-            auth=(self.username, self.password),
-            headers=headers,
-            verify=not self.ignore_ssl_check,
-        )
+        body_excerpt = response.text.strip()[:300] if response.text else ""
+        detail = detail or body_excerpt or "Unexpected error from Confluence."
+        return f"HTTP {status}: {detail}"
+
+    # ------------------------------------------------------------------
+    # Legacy helpers kept for other tools in the plugin
+    # ------------------------------------------------------------------
+    def create_page(self, title: str, content: str, space_key: str):
+        url = f"{self.site_url}rest/api/content"
+        data = {
+            "type": "page",
+            "title": title,
+            "space": {"key": space_key},
+            "body": {"storage": {"value": content, "representation": "storage"}},
+        }
+        headers = {"Content-Type": "application/json"}
+        response = self._request("POST", url, json=data, headers=headers)
         return response.json()
 
-    def update_page(self, page_id, title, content):
+    def update_page(self, page_id: str, title: str, content: str):
         url = f"{self.site_url}rest/api/content/{page_id}"
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        headers = {"Content-Type": "application/json"}
+        current_page = self._request("GET", url, headers=headers).json()
 
-        current_page = requests.get(
-            url,
-            auth=(self.username, self.password),
-            headers=headers,
-            verify=not self.ignore_ssl_check,
-        ).json()
-
-        version_number = current_page.get("version", {}).get("number", 1) + 1
+        new_version = current_page.get("version", {}).get("number", 0) + 1
 
         data = {
             "id": page_id,
             "type": "page",
             "title": title,
-            "version": {"number": version_number},
-            "body": {
-                "storage": {"value": content, "representation": "storage"},
-            },
+            "body": {"storage": {"value": content, "representation": "storage"}},
+            "version": {"number": new_version},
         }
 
-        response = requests.put(
-            url,
-            json=data,
-            auth=(self.username, self.password),
-            headers=headers,
-            verify=not self.ignore_ssl_check,
-        )
+        response = self._request("PUT", url, json=data, headers=headers)
         return response.json()

--- a/tests/python/unit/test_confluence_search_tool.py
+++ b/tests/python/unit/test_confluence_search_tool.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -10,14 +11,16 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 sys.path.append(str(ROOT_DIR / "python-lib"))
 
 
+# ---------------------------------------------------------------------------
+# Lightweight stubs so the tool module can be imported in isolation
+# ---------------------------------------------------------------------------
 if "dataiku" not in sys.modules:
     dataiku_module = types.ModuleType("dataiku")
     llm_module = types.ModuleType("dataiku.llm")
     agent_tools_module = types.ModuleType("dataiku.llm.agent_tools")
 
-    class _BaseAgentTool:  # pragma: no cover - trivial stub
-        def __init__(self, *args, **kwargs):
-            pass
+    class _BaseAgentTool:  # pragma: no cover - minimal shim
+        pass
 
     agent_tools_module.BaseAgentTool = _BaseAgentTool
     llm_module.agent_tools = agent_tools_module
@@ -31,20 +34,32 @@ if "dataiku" not in sys.modules:
 if "requests" not in sys.modules:
     requests_module = types.ModuleType("requests")
 
-    def _request_stub(*args, **kwargs):  # pragma: no cover - safety stub
-        raise NotImplementedError("The requests module is not available in the test environment.")
-
-    requests_module.get = _request_stub
-    requests_module.post = _request_stub
-
     class _RequestException(Exception):
         pass
 
-    requests_module.RequestException = _RequestException
-
     class _Response:  # pragma: no cover - minimal placeholder
-        pass
+        def __init__(self, status_code=200, payload=None, text="", ok=True):
+            self.status_code = status_code
+            self._payload = payload
+            self.text = text
+            self.ok = ok
+            self.content = b"{}" if payload is not None else b""
 
+        def json(self):
+            if self._payload is None:
+                raise ValueError("No JSON payload available")
+            return self._payload
+
+    class _Session:
+        def __init__(self):
+            self.headers = {}
+            self.verify = True
+
+        def request(self, *args, **kwargs):  # pragma: no cover - guard
+            raise NotImplementedError("requests stub is not configured")
+
+    requests_module.Session = _Session
+    requests_module.RequestException = _RequestException
     requests_module.Response = _Response
     sys.modules["requests"] = requests_module
 
@@ -68,12 +83,16 @@ from confluence_client import ConfluenceClient
 
 
 class DummyResponse:
-    def __init__(self, status_code, payload, text=""):
+    def __init__(self, status_code=200, payload=None, text="", ok=None):
         self.status_code = status_code
         self._payload = payload
-        self.text = text or ""
+        self.text = text
+        self.ok = True if ok is None else ok
+        self.content = b"{}" if payload is not None else b""
 
     def json(self):
+        if self._payload is None:
+            raise ValueError("No JSON payload available")
         return self._payload
 
 
@@ -85,174 +104,224 @@ class DummyTrace:
         self.attributes = {}
 
 
-def test_confluence_client_prefers_v2(monkeypatch):
-    client = ConfluenceClient(
-        {
-            "server_type": "cloud",
-            "subdomain": "example",
+def _load_tool():
+    tool = ConfluenceSearchPagesTool()
+    config = {
+        "access_type": "token_access",
+        "token_access": {
+            "server_type": "on_premise",
+            "api_url": "https://confluence.example.com/",
+            "ignore_ssl_check": False,
             "username": "user",
             "token": "token",
-        }
-    )
+        },
+        "space_key": "AIEC",
+        "limit": "5",
+    }
+    tool.set_config(config, {})
+    return tool
 
+
+def test_confluence_client_builds_expected_cql(monkeypatch):
     captured = {}
 
-    def fake_post(url, json=None, auth=None, headers=None, verify=None):
+    def fake_request(self, method, url, params=None, **kwargs):
+        captured["method"] = method
         captured["url"] = url
-        captured["json"] = json
-        return DummyResponse(
-            200,
-            {
-                "results": [
-                    {
-                        "content": {
-                            "id": "123",
-                            "title": "Demo Page",
-                            "_links": {"webui": "/wiki/spaces/SPACE/pages/123/Demo+Page"},
-                        },
-                        "excerpt": "Demo excerpt",
-                    }
-                ]
-            },
-        )
+        captured["params"] = params
+        payload = {
+            "results": [
+                {
+                    "id": "123",
+                    "title": "Dataiku Page",
+                    "_links": {"webui": "/display/AIEC/Dataiku"},
+                    "excerpt": "Snippet",
+                    "lastModified": "2024-01-01T00:00:00Z",
+                    "space": {"key": "AIEC"},
+                }
+            ]
+        }
+        return DummyResponse(payload=payload)
 
-    def fake_get(*args, **kwargs):  # pragma: no cover - defensive fallback
-        raise AssertionError("v1 search should not be used when v2 succeeds")
+    monkeypatch.setattr(requests.Session, "request", fake_request)
 
-    monkeypatch.setattr(requests, "post", fake_post)
-    monkeypatch.setattr(requests, "get", fake_get)
-
-    result = client.search_pages("demo", limit=2, space_key="SPACE")
-
-    assert result["source"] == "v2"
-    assert captured["json"]["spaceKeys"] == ["SPACE"]
-    assert captured["json"]["limit"] == 2
-    assert result["results"][0]["title"] == "Demo Page"
-    assert result["results"][0]["url"].endswith("/wiki/spaces/SPACE/pages/123/Demo+Page")
-
-
-def test_confluence_client_falls_back_to_v1(monkeypatch):
     client = ConfluenceClient(
         {
             "server_type": "on_premise",
             "api_url": "https://confluence.example.com/",
+            "ignore_ssl_check": False,
             "username": "user",
-            "token": "token",
+            "token": "pass",
         }
     )
 
-    def fake_post(url, json=None, auth=None, headers=None, verify=None):
-        return DummyResponse(404, {"message": "not found"}, text="not found")
+    result = client.search_pages("what is Dataiku?", limit=3, space_key="AIEC")
 
-    def fake_get(url, params=None, auth=None, headers=None, verify=None):
-        return DummyResponse(
-            200,
-            {
-                "results": [
-                    {
-                        "content": {
-                            "id": "456",
-                            "title": "Legacy Page",
-                            "_links": {"webui": "/display/SPACE/Legacy+Page"},
-                            "space": {"key": "SPACE"},
-                        },
-                        "excerpt": "Legacy excerpt",
-                    }
-                ]
-            },
-        )
-
-    monkeypatch.setattr(requests, "post", fake_post)
-    monkeypatch.setattr(requests, "get", fake_get)
-
-    result = client.search_pages("legacy", limit=1, space_key="SPACE")
-
-    assert result["source"] == "v1"
-    assert len(result["attempts"]) == 3
-    assert result["attempts"][-1]["version"] == "v1"
-    assert result["results"][0]["space_key"] == "SPACE"
-    assert result["results"][0]["url"].endswith("/display/SPACE/Legacy+Page")
+    assert captured["method"] == "GET"
+    assert captured["url"].endswith("/rest/api/search")
+    assert captured["params"]["limit"] == 3
+    assert (
+        captured["params"]["cql"]
+        == 'type=page AND space = "AIEC" AND text ~ "what is Dataiku" ORDER BY lastmodified DESC'
+    )
+    assert result["attempts"][0] == (
+        'CQL=type=page AND space = "AIEC" AND text ~ "what is Dataiku" ORDER BY lastmodified DESC'
+    )
+    assert result["results"][0]["url"].endswith("/display/AIEC/Dataiku")
+    assert result["results"][0]["space_key"] == "AIEC"
 
 
-def test_confluence_client_reports_error(monkeypatch):
+def test_confluence_client_sanitizes_newlines_in_query(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, url, params=None, **kwargs):
+        captured["params"] = params
+        return DummyResponse(payload={"results": []})
+
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+
     client = ConfluenceClient(
         {
-            "server_type": "cloud",
-            "subdomain": "example",
-            "username": "user",
-            "token": "token",
+            "server_type": "on_premise",
+            "api_url": "https://confluence.example.com/",
         }
     )
 
-    def fake_post(url, json=None, auth=None, headers=None, verify=None):
-        return DummyResponse(500, {"message": "internal error"}, text="internal error")
+    client.search_pages("Line1\nLine2?", limit=1)
 
-    def fake_get(*args, **kwargs):  # pragma: no cover - defensive fallback
-        raise AssertionError("v1 search should not execute on fatal v2 errors")
-
-    monkeypatch.setattr(requests, "post", fake_post)
-    monkeypatch.setattr(requests, "get", fake_get)
-
-    result = client.search_pages("demo", limit=3)
-
-    assert result["source"] == "v2"
-    assert result["error"]["message"] == "internal error"
-    assert result["error"]["status_code"] == 500
+    cql = captured["params"]["cql"]
+    assert "\n" not in cql
+    assert cql.endswith('text ~ "Line1 Line2" ORDER BY lastmodified DESC')
 
 
-def test_tool_invoke_formats_results_and_trace(monkeypatch):
-    tool_instance = ConfluenceSearchPagesTool()
+def test_confluence_client_returns_error_message(monkeypatch):
+    def fake_request(self, method, url, params=None, **kwargs):
+        payload = {"message": "cql query parameter is required"}
+        return DummyResponse(status_code=400, payload=payload, text=json.dumps(payload), ok=False)
+
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+
+    client = ConfluenceClient(
+        {
+            "server_type": "on_premise",
+            "api_url": "https://confluence.example.com/",
+        }
+    )
+
+    result = client.search_pages("Dataiku", limit=0)
+
+    assert result["results"] == []
+    assert result["error"]["message"].startswith("HTTP 400:")
+    assert result["message"].startswith("HTTP 400:")
+
+
+def test_confluence_client_skips_non_dict_entries(monkeypatch):
+    def fake_request(self, method, url, params=None, **kwargs):
+        payload = {"results": ["invalid", {"id": "42", "title": "Valid", "_links": {"self": "https://example.com"}}]}
+        return DummyResponse(payload=payload)
+
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+
+    client = ConfluenceClient(
+        {
+            "server_type": "on_premise",
+            "api_url": "https://confluence.example.com/",
+        }
+    )
+
+    result = client.search_pages("Dataiku", limit=5)
+
+    assert len(result["results"]) == 1
+    assert result["results"][0]["title"] == "Valid"
+    assert any("Skipped non-dict search entry" in attempt for attempt in result["attempts"])
+
+
+def test_get_page_content_requests_body_storage(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, url, params=None, **kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["params"] = params
+        payload = {"body": {"storage": {"value": "<p>Body</p>"}}}
+        return DummyResponse(payload=payload)
+
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+
+    client = ConfluenceClient(
+        {
+            "server_type": "on_premise",
+            "api_url": "https://confluence.example.com/",
+        }
+    )
+
+    payload = client.get_page_content("123")
+
+    assert captured["method"] == "GET"
+    assert captured["url"].endswith("/rest/api/content/123")
+    assert captured["params"] == {"expand": "body.storage"}
+    assert payload["body"]["storage"]["value"] == "<p>Body</p>"
+
+
+def test_tool_applies_defaults_and_returns_results(monkeypatch):
+    tool = _load_tool()
+
+    recorded = {}
 
     class DummyClient:
         site_url = "https://confluence.example.com/"
 
-        def search_pages(self, query, limit=3, space_key=None):
+        def search_pages(self, query, limit=None, space_key=None):
+            recorded["query"] = query
+            recorded["limit"] = limit
+            recorded["space_key"] = space_key
             return {
                 "results": [
                     {
-                        "id": "789",
-                        "title": "Tool Page",
-                        "url": "https://confluence.example.com/display/SPACE/Tool+Page",
-                        "excerpt": "Tool excerpt",
-                        "last_modified": "2024-01-01T00:00:00.000Z",
-                        "space_key": space_key,
-                    },
-                    {
-                        "id": "000",
-                        "title": "Should be trimmed",
-                        "url": "https://confluence.example.com/display/SPACE/Trimmed",
-                    },
+                        "id": "123",
+                        "title": "Dataiku",
+                        "url_path": "/display/AIEC/Dataiku",
+                        "space_key": "AIEC",
+                    }
                 ],
-                "source": "v2",
-                "attempts": [
-                    {"version": "v2", "status_code": 200},
-                ],
+                "attempts": ["ok"],
+                "source": "confluence",
             }
 
         def get_page_content(self, page_id):
-            return {
-                "body": {
-                    "storage": {
-                        "value": f"<p>Content for {page_id}</p>",
-                    }
-                }
-            }
+            return {"body": {"storage": {"value": "<p>Content</p>"}}}
 
-    tool_instance.client = DummyClient()
+    tool.client = DummyClient()
 
     trace = DummyTrace()
+    response = tool.invoke({"input": {"query": "Dataiku"}}, trace)
 
-    result = tool_instance.invoke(
-        {"input": {"query": "tool", "space_key": "SPACE", "limit": 1}},
-        trace,
-    )
+    assert recorded == {"query": "Dataiku", "limit": 5, "space_key": "AIEC"}
+    assert len(response["results"]) == 1
+    assert response["results"][0]["page_content"] == "<p>Content</p>"
+    assert trace.outputs["results"][0]["url"].endswith("/display/AIEC/Dataiku")
 
-    assert trace.attributes["config"]["limit"] == 1
-    assert trace.attributes["search"]["source"] == "v2"
-    assert trace.attributes["search"]["space_key"] == "SPACE"
-    assert len(result["results"]) == 1
-    item = result["results"][0]
-    assert item["page_id"] == "789"
-    assert "Tool excerpt" in item["excerpt"]
-    assert item["page_content"] == "<p>Content for 789</p>"
-    assert trace.outputs["results"] == result["results"]
+
+def test_tool_surfaces_error_message(monkeypatch):
+    tool = _load_tool()
+
+    class DummyClient:
+        site_url = "https://confluence.example.com/"
+
+        def search_pages(self, query, limit=None, space_key=None):
+            return {
+                "results": [],
+                "error": {"message": "HTTP 400: cql query parameter is required"},
+                "message": "HTTP 400: cql query parameter is required",
+                "attempts": ["failure"],
+                "source": "confluence",
+            }
+
+    tool.client = DummyClient()
+
+    trace = DummyTrace()
+    response = tool.invoke({"input": {"query": "Dataiku"}}, trace)
+
+    assert response["output"].startswith("HTTP 400:")
+    assert response["results"] == []
+    assert trace.outputs["message"].startswith("HTTP 400:")


### PR DESCRIPTION
## Summary
- rebuild the Confluence client so it composes safe CQL queries for /rest/api/search, honours auth/SSL settings, reports backend errors, and fetches page bodies with expand=body.storage
- add targeted unit coverage for the client and tool to confirm default space/limit handling, CQL formatting, content expansion, and surfaced error messages
- skip malformed search rows returned by Confluence while recording the discarded entry in the attempts log
- normalise newline characters in search queries before composing CQL to prevent parse failures and cover the behaviour with a dedicated unit test

## Testing
- pytest tests/python/unit/test_confluence_search_tool.py

------
https://chatgpt.com/codex/tasks/task_e_68e3ac1a79d0832795b2f809b39e1792