### PR TITLE
Simplify Confluence search client and update tool defaults

### DIFF
--- a/python-agent-tools/search-confluence-pages/tool.py
+++ b/python-agent-tools/search-confluence-pages/tool.py
@@ -84,8 +84,18 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
             query = ""
         else:
             query = str(query_value)
-        space_key = self._normalize_space_key(args.get("space_key"))
-        limit_value = self._sanitize_limit(args.get("limit", 3))
+        default_space = None
+        if hasattr(self, "config") and isinstance(getattr(self, "config"), dict):
+            default_space = self.config.get("space_key")
+        space_key = self._normalize_space_key(
+            args.get("space_key") or default_space
+        )
+        default_limit = 3
+        if hasattr(self, "config") and isinstance(getattr(self, "config"), dict):
+            default_limit = self.config.get("limit", 3)
+        limit_value = self._sanitize_limit(
+            args.get("limit", default_limit), default=default_limit
+        )
 
         confluence_instance_url = self.client.site_url or ""
         base_url = (

--- a/python-lib/confluence_client.py
+++ b/python-lib/confluence_client.py
@@ -1,5 +1,4 @@
 import logging
-from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode, urljoin
 
@@ -36,14 +35,14 @@ class ConfluenceClient:
         password = connection_details.get("password")
         token = connection_details.get("token")
 
+        # Prefer Basic if username+password provided; otherwise Bearer if only token provided
         if username and (password or token):
             self.session.auth = (username, password or token)
         elif token:
             self.session.headers.update({"Authorization": f"Bearer {token}"})
 
-    # ------------------------------------------------------------------
-    # REST helpers
-    # ------------------------------------------------------------------
+    # ---------------------------- internal helpers ----------------------------
+
     def _request(self, method: str, url: str, **kwargs) -> requests.Response:
         kwargs.setdefault("timeout", 30)
         return self.session.request(method, url, **kwargs)
@@ -53,150 +52,15 @@ class ConfluenceClient:
         if value is None:
             return ""
         text = str(value)
-        replacements = {
-            "\\": "\\\\",
-            '"': '\\"',
-        }
-        for original, escaped in replacements.items():
-            text = text.replace(original, escaped)
+        # escape backslash and double quotes
+        text = text.replace("\\", "\\\\").replace('"', '\\"')
         return text
-
-    @staticmethod
-    def _coerce_positive_int(value: Any, default: int = 3) -> int:
-        try:
-            parsed = int(value)
-        except (TypeError, ValueError):
-            return default
-        return parsed if parsed > 0 else default
-
-    def _normalise_space_key(self, space_key: Optional[str]) -> Optional[str]:
-        if space_key is None:
-            return None
-        if isinstance(space_key, str):
-            stripped = space_key.strip()
-            return stripped or None
-        return str(space_key).strip() or None
-
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
-    def search_pages(self, query: str, limit: int = 3, space_key: Optional[str] = None) -> Dict[str, Any]:
-        attempts: List[str] = []
-
-        limit_value = self._coerce_positive_int(limit, default=3)
-
-        query_text = (query or "").strip()
-        if query_text.endswith("?"):
-            query_text = query_text[:-1].strip()
-
-        cql_parts = ["type=page"]
-
-        normalised_space = self._normalise_space_key(space_key)
-        if normalised_space:
-            escaped_space = self._escape_cql_value(normalised_space)
-            cql_parts.append(f'space = "{escaped_space}"')
-
-        if query_text:
-            escaped_query = self._escape_cql_value(query_text)
-            cql_parts.append(f'text ~ "{escaped_query}"')
-
-        cql = " AND ".join(cql_parts) + " ORDER BY lastmodified DESC"
-        attempts.append(f"CQL={cql}")
-
-        url = f"{self.base_url}/rest/api/search"
-        params = {"cql": cql, "limit": limit_value}
-        attempts.append(f"GET {url}?{urlencode(params)}")
-
-        try:
-            response = self._request("GET", url, params=params)
-        except requests.RequestException as exc:  # pragma: no cover - network failure
-            message = f"Request failed: {exc}"
-            return {
-                "results": [],
-                "error": {"message": message},
-                "source": "confluence",
-                "attempts": attempts,
-                "message": message,
-            }
-
-            if version == "v2" and response.status_code in {404, 405}:
-                attempt_record["error"] = "search endpoint unavailable"
-                self._search_v2_supported = False
-                attempts.append(attempt_record)
-                continue
-
-            if version == "v2" and response.status_code < 400:
-                self._search_v2_supported = True
-
-            if response.status_code >= 400:
-                error_payload = self._safe_json(response)
-                attempt_record["error"] = self._extract_error_message(error_payload, response.text)
-                attempts.append(attempt_record)
-                return {
-                    "results": [],
-                    "error": {
-                        "message": attempt_record["error"],
-                        "status_code": response.status_code,
-                        "details": error_payload,
-                    },
-                    "attempts": attempts,
-                    "source": version,
-                    "message": attempt_record["error"],
-                }
-
-            try:
-                payload = response.json()
-            except ValueError:
-                attempt_record["error"] = "invalid JSON response"
-                attempts.append(attempt_record)
-                return {
-                    "results": [],
-                    "error": {
-                        "message": "Unexpected response from Confluence search endpoint.",
-                        "status_code": response.status_code,
-                        "details": response.text,
-                    },
-                    "attempts": attempts,
-                    "source": version,
-                }
-
-            attempts.append(attempt_record)
-            normalized_results = self._normalize_results(payload, version)
-            return {
-                "results": [],
-                "error": {"message": message},
-                "source": "confluence",
-                "attempts": attempts,
-                "message": message,
-            }
-
-        results = [self._normalise_result_entry(entry) for entry in payload.get("results", []) or []]
-
-        return {
-            "results": results,
-            "source": "confluence",
-            "attempts": attempts,
-            "source": None,
-            "message": "No supported Confluence search endpoint responded successfully.",
-        }
-
-    def get_page_content(self, page_id: str) -> Dict[str, Any]:
-        url = f"{self.base_url}/rest/api/content/{page_id}"
-        params = {"expand": "body.storage"}
-
-        try:
-            parsed = int(limit)
-        except (TypeError, ValueError):
-            return 3
-        return parsed if parsed > 0 else 3
 
     @staticmethod
     def _normalize_query(query: Any) -> str:
         if query is None:
             return ""
-        if isinstance(query, str):
-            return query.strip()
-        return str(query)
+        return query.strip() if isinstance(query, str) else str(query).strip()
 
     @staticmethod
     def _normalize_space_key(space_key: Optional[str]) -> Optional[str]:
@@ -209,113 +73,88 @@ class ConfluenceClient:
         return text or None
 
     @staticmethod
-    def _escape_cql_value(value: Any) -> str:
-        if value is None:
-            return ""
-        text = str(value)
-        text = text.replace("\\", "\\\\")
-        text = text.replace('"', '\\"')
-        return text
+    def _coerce_positive_int(value: Any, default: int = 3) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
 
-    def _build_v2_payload(self, query: str, limit: int, space_key: Optional[str]) -> Dict[str, Any]:
-        normalized_query = self._normalize_query(query)
-        escaped_query = self._escape_cql_value(normalized_query)
-        query_string = f'text ~ "{escaped_query}"'
-        payload: Dict[str, Any] = {
-            "queryString": query_string,
-            "entityType": ["page"],
-            "limit": limit,
-            "sort": "modified_date DESC",
-        }
-        normalized_space = self._normalize_space_key(space_key)
-        if normalized_space:
-            payload["spaceKeys"] = [normalized_space]
-        return payload
+    # ------------------------------- public API --------------------------------
 
-    def _build_v1_params(self, query: str, limit: int, space_key: Optional[str]) -> Dict[str, Any]:
-        cql_parts = []
-        if space_key:
-            cql_parts.append(f'space="{space_key}"')
-        cql_parts.append(f'text~"{query}"')
-        cql_query = " AND ".join(cql_parts)
-        return f"{cql_query} ORDER BY lastmodified DESC"
+    def search_pages(self, query: str, limit: int = 3, space_key: Optional[str] = None) -> Dict[str, Any]:
+        attempts: List[str] = []
 
-    def _compose_v1_cql_query(self, query: str, space_key: Optional[str]) -> str:
-        """Build the Confluence Query Language string for v1 searches.
+        limit_value = self._coerce_positive_int(limit, default=3)
 
-        Space scoping is embedded directly in the CQL so that on-premises
-        instances honour the restriction instead of relying on a separate
-        ``space`` query parameter, which the endpoint ignores.
-        """
+        qtext = self._normalize_query(query)
+        if qtext.endswith("?"):
+            qtext = qtext[:-1].strip()
 
-        cql_parts = []
-        normalized_space = self._normalize_space_key(space_key)
-        if normalized_space:
-            escaped_space = self._escape_cql_value(normalized_space)
-            cql_parts.append(f'space="{escaped_space}"')
-        normalized_query = self._normalize_query(query)
-        escaped_query = self._escape_cql_value(normalized_query)
-        cql_parts.append(f'text~"{escaped_query}"')
-        cql_query = " AND ".join(cql_parts)
-        return f"{cql_query} ORDER BY lastmodified DESC"
+        cql_parts = ["type=page"]
+        if space_key := self._normalize_space_key(space_key):
+            cql_parts.append(f'space = "{self._escape_cql_value(space_key)}"')
+        if qtext:
+            cql_parts.append(f'text ~ "{self._escape_cql_value(qtext)}"')
 
-    def _compose_v1_cql_query(self, query: str, space_key: Optional[str]) -> str:
-        """Build the Confluence Query Language string for v1 searches.
+        cql = " AND ".join(cql_parts) + " ORDER BY lastmodified DESC"
+        attempts.append(f"CQL={cql}")
 
-        Space scoping is embedded directly in the CQL so that on-premises
-        instances honour the restriction instead of relying on a separate
-        ``space`` query parameter, which the endpoint ignores.
-        """
-
-        cql_parts = []
-        normalized_space = self._normalize_space_key(space_key)
-        if normalized_space:
-            escaped_space = self._escape_cql_value(normalized_space)
-            cql_parts.append(f'space="{escaped_space}"')
-        normalized_query = self._normalize_query(query)
-        escaped_query = self._escape_cql_value(normalized_query)
-        cql_parts.append(f'text~"{escaped_query}"')
-        cql_query = " AND ".join(cql_parts)
-        return f"{cql_query} ORDER BY lastmodified DESC"
-
-    def _search_endpoint_candidates(self) -> List[Dict[str, str]]:
-        base_url = self.site_url
-        candidates: List[Dict[str, str]] = []
-
-        prefer_v2 = self.server_type == "cloud" and self._search_v2_supported is not False
-
-        if prefer_v2:
-            # Primary v2 endpoint relative to the configured site URL.
-            v2_primary = urljoin(base_url, "api/v2/search")
-            candidates.append({"version": "v2", "method": "POST", "url": v2_primary})
-
-            # Some instances expose v2 under /wiki/api/v2/ even when the base URL
-            # does not include /wiki/.
-            v2_alt = urljoin(base_url, "wiki/api/v2/search")
-            if v2_alt != v2_primary:
-                candidates.append({"version": "v2", "method": "POST", "url": v2_alt})
-
-        # Legacy v1 endpoint fallback.
-        v1_url = urljoin(base_url, "rest/api/content/search")
-        candidates.append({"version": "v1", "method": "GET", "url": v1_url})
-
-        return candidates
-
-    def _normalize_results(self, payload: Dict[str, Any], version: str) -> List[Dict[str, Any]]:
-        results: List[Dict[str, Any]] = []
-        for entry in payload.get("results", []) or []:
-            normalized = self._normalize_entry(entry, version)
-            results.append(normalized)
-        return results
+        url = f"{self.base_url}/rest/api/search"
+        params = {"cql": cql, "limit": limit_value}
+        attempts.append(f"GET {url}?{urlencode(params)}")
 
         try:
-            return response.json() if response.content else {}
+            resp = self._request("GET", url, params=params)
+        except requests.RequestException as exc:
+            message = f"Request failed: {exc}"
+            return {
+                "results": [],
+                "error": {"message": message},
+                "source": "confluence",
+                "attempts": attempts,
+                "message": message,
+            }
+
+        if not resp.ok:
+            message = self._build_error_message(resp)
+            return {
+                "results": [],
+                "error": {"message": message},
+                "source": "confluence",
+                "attempts": attempts,
+                "message": message,
+            }
+
+        try:
+            payload = resp.json() if resp.content else {}
+        except ValueError:
+            message = "Unable to decode Confluence response as JSON."
+            return {
+                "results": [],
+                "error": {"message": message},
+                "source": "confluence",
+                "attempts": attempts,
+                "message": message,
+            }
+
+        raw_items = payload.get("results") or []
+        results = [self._normalise_result_entry(entry) for entry in raw_items]
+        return {"results": results[:limit_value], "source": "confluence", "attempts": attempts}
+
+    def get_page_content(self, page_id: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/rest/api/content/{page_id}"
+        params = {"expand": "body.storage"}
+        resp = self._request("GET", url, params=params)
+        if not resp.ok:
+            return {"error": {"message": self._build_error_message(resp)}}
+        try:
+            return resp.json() if resp.content else {}
         except ValueError:
             return {"error": {"message": "Unable to decode Confluence response as JSON."}}
 
-    # ------------------------------------------------------------------
-    # Normalisation helpers
-    # ------------------------------------------------------------------
+    # --------------------------- normalisation helpers --------------------------
+
     def _normalise_result_entry(self, entry: Dict[str, Any]) -> Dict[str, Any]:
         content = entry.get("content") if isinstance(entry.get("content"), dict) else {}
 
@@ -371,7 +210,6 @@ class ConfluenceClient:
 
     def _build_error_message(self, response: requests.Response) -> str:
         status = response.status_code
-
         detail: Optional[str] = None
         try:
             payload = response.json()
@@ -389,9 +227,8 @@ class ConfluenceClient:
         detail = detail or body_excerpt or "Unexpected error from Confluence."
         return f"HTTP {status}: {detail}"
 
-    # ------------------------------------------------------------------
-    # Legacy helpers kept for other tools in the plugin
-    # ------------------------------------------------------------------
+    # ---------------- legacy helpers retained for other plugin features --------
+
     def create_page(self, title: str, content: str, space_key: str):
         url = f"{self.site_url}rest/api/content"
         data = {

--- a/tests/python/unit/test_confluence_search_tool.py
+++ b/tests/python/unit/test_confluence_search_tool.py
@@ -1,10 +1,8 @@
-import importlib.util
 import json
 import sys
 import types
 from pathlib import Path
-
-import pytest
+import importlib.util
 
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
@@ -83,12 +81,15 @@ from confluence_client import ConfluenceClient
 
 
 class DummyResponse:
-    def __init__(self, status_code=200, payload=None, text="", ok=None):
+    def __init__(self, status_code=200, payload=None, text="", ok=None, content=None):
         self.status_code = status_code
         self._payload = payload
         self.text = text
         self.ok = True if ok is None else ok
-        self.content = b"{}" if payload is not None else b""
+        if content is not None:
+            self.content = content
+        else:
+            self.content = b"{}" if payload is not None else b""
 
     def json(self):
         if self._payload is None:
@@ -122,7 +123,7 @@ def _load_tool():
     return tool
 
 
-def test_confluence_client_builds_expected_cql(monkeypatch):
+def test_confluence_client_search_pages_builds_expected_cql(monkeypatch):
     captured = {}
 
     def fake_request(self, method, url, params=None, **kwargs):
@@ -133,11 +134,14 @@ def test_confluence_client_builds_expected_cql(monkeypatch):
             "results": [
                 {
                     "id": "123",
-                    "title": "Dataiku Page",
-                    "_links": {"webui": "/display/AIEC/Dataiku"},
+                    "content": {
+                        "id": "123",
+                        "title": "Dataiku Page",
+                        "_links": {"webui": "/display/AIEC/Dataiku"},
+                        "space": {"key": "AIEC"},
+                    },
                     "excerpt": "Snippet",
                     "lastModified": "2024-01-01T00:00:00Z",
-                    "space": {"key": "AIEC"},
                 }
             ]
         }
@@ -167,90 +171,55 @@ def test_confluence_client_builds_expected_cql(monkeypatch):
     assert result["attempts"][0] == (
         'CQL=type=page AND space = "AIEC" AND text ~ "what is Dataiku" ORDER BY lastmodified DESC'
     )
+    assert result["attempts"][1].startswith("GET")
     assert result["results"][0]["url"].endswith("/display/AIEC/Dataiku")
     assert result["results"][0]["space_key"] == "AIEC"
 
-    monkeypatch.setattr(requests.Session, "request", fake_request)
 
-def test_confluence_client_returns_error_message(monkeypatch):
+def test_confluence_client_search_pages_handles_error(monkeypatch):
     def fake_request(self, method, url, params=None, **kwargs):
         payload = {"message": "cql query parameter is required"}
         return DummyResponse(status_code=400, payload=payload, text=json.dumps(payload), ok=False)
 
     monkeypatch.setattr(requests.Session, "request", fake_request)
 
-def test_confluence_client_uses_v1_on_on_prem(monkeypatch):
-    client = ConfluenceClient(
-        {
-            "server_type": "on_premise",
-            "api_url": "https://confluence.example.com/",
-        }
-    )
+    client = ConfluenceClient({"api_url": "https://confluence.example.com/"})
 
-    captured = {}
+    result = client.search_pages("Dataiku")
 
-    def fake_post(*args, **kwargs):  # pragma: no cover - defensive guard
-        raise AssertionError("v2 search should not be attempted for on-prem instances")
-
-    captured = {}
-
-    def fake_get(url, params=None, auth=None, headers=None, verify=None):
-        captured["url"] = url
-        captured["params"] = params
-        return DummyResponse(
-            200,
-            {
-                "results": [
-                    {
-                        "content": {
-                            "id": "456",
-                            "title": "Legacy Page",
-                            "_links": {"webui": "/display/SPACE/Legacy+Page"},
-                            "space": {"key": "SPACE"},
-                        },
-                        "excerpt": "Legacy excerpt",
-                    }
-                ]
-            },
-    )
+    assert result["results"] == []
+    assert "HTTP 400" in result["error"]["message"]
+    assert result["message"].startswith("HTTP 400")
 
 
-def test_get_page_content_requests_body_storage(monkeypatch):
-    captured = {}
-
-    assert result["source"] == "v1"
-    assert len(result["attempts"]) == 3
-    assert result["attempts"][-1]["version"] == "v1"
-    assert captured["params"]["limit"] == 1
-    assert captured["params"]["cql"].startswith('space="SPACE" AND text~"legacy"')
-    assert result["results"][0]["space_key"] == "SPACE"
-    assert result["results"][0]["url"].endswith("/display/SPACE/Legacy+Page")
+def test_confluence_client_search_pages_handles_request_exception(monkeypatch):
+    def fake_request(self, method, url, params=None, **kwargs):  # pragma: no cover - stub
+        raise requests.RequestException("boom")
 
     monkeypatch.setattr(requests.Session, "request", fake_request)
 
-def test_compose_v1_cql_query_scopes_space():
-    client = ConfluenceClient(
-        {
-            "server_type": "on_premise",
-            "api_url": "https://confluence.example.com/",
-            "username": "user",
-            "token": "token",
-        }
-    )
+    client = ConfluenceClient({"api_url": "https://confluence.example.com/"})
 
-    cql = client._compose_v1_cql_query(query="Dataiku", space_key="AIEC")
+    result = client.search_pages("Dataiku")
 
-    assert cql.startswith('space="AIEC" AND text~"Dataiku"')
-    assert cql.endswith("ORDER BY lastmodified DESC")
+    assert result["results"] == []
+    assert result["error"]["message"] == "Request failed: boom"
+    assert result["message"] == "Request failed: boom"
 
 
-def test_confluence_client_reports_error(monkeypatch):
-    client = ConfluenceClient(
-        {
-            "server_type": "on_premise",
-            "api_url": "https://confluence.example.com/",
-        }
-    )
+def test_confluence_client_get_page_content_requests_body_storage(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, url, params=None, **kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["params"] = params
+        payload = {"body": {"storage": {"value": "<p>Body</p>"}}}
+        return DummyResponse(payload=payload)
+
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+
+    client = ConfluenceClient({"api_url": "https://confluence.example.com/"})
 
     payload = client.get_page_content("123")
 
@@ -260,10 +229,21 @@ def test_confluence_client_reports_error(monkeypatch):
     assert payload["body"]["storage"]["value"] == "<p>Body</p>"
 
 
-    assert result["source"] == "v2"
-    assert result["error"]["message"] == "internal error"
-    assert result["error"]["status_code"] == 500
-    assert result["message"] == "internal error"
+def test_confluence_client_get_page_content_handles_decode_error(monkeypatch):
+    def fake_request(self, method, url, params=None, **kwargs):
+        return DummyResponse(payload=None, ok=True, content=b"not-json")
+
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+
+    client = ConfluenceClient({"api_url": "https://confluence.example.com/"})
+
+    payload = client.get_page_content("123")
+
+    assert payload["error"]["message"] == "Unable to decode Confluence response as JSON."
+
+
+def test_tool_invoke_uses_defaults_and_fetches_page_content():
+    tool = _load_tool()
 
     recorded = {}
 
@@ -301,7 +281,7 @@ def test_confluence_client_reports_error(monkeypatch):
     assert trace.outputs["results"][0]["url"].endswith("/display/AIEC/Dataiku")
 
 
-def test_tool_surfaces_error_message(monkeypatch):
+def test_tool_invoke_surfaces_error_message():
     tool = _load_tool()
 
     class DummyClient:
@@ -321,78 +301,14 @@ def test_tool_surfaces_error_message(monkeypatch):
     trace = DummyTrace()
     response = tool.invoke({"input": {"query": "Dataiku"}}, trace)
 
-    result = tool_instance.invoke(
-        {"input": {"query": "tool", "space_key": "SPACE", "limit": 1}},
-        trace,
-    )
-
-    assert trace.attributes["config"]["limit"] == 1
-    assert trace.inputs["query"] == "tool"
-    assert trace.inputs["limit"] == 1
-    assert trace.inputs["space_key"] == "SPACE"
-    assert trace.attributes["search"]["source"] == "v2"
-    assert trace.attributes["search"]["space_key"] == "SPACE"
-    assert len(result["results"]) == 1
-    item = result["results"][0]
-    assert item["page_id"] == "789"
-    assert "Tool excerpt" in item["excerpt"]
-    assert item["page_content"] == "<p>Content for 789</p>"
-    assert trace.outputs["results"] == result["results"]
-
-
-
-def test_compose_v1_cql_query_escapes_special_characters():
-    client = ConfluenceClient(
-        {
-            "server_type": "on_premise",
-            "api_url": "https://confluence.example.com/",
-            "username": "user",
-            "token": "token",
-        }
-    )
-
-    raw_query = 'Data "iku" \\ story'
-    raw_space = ' A"IEC '
-    cql = client._compose_v1_cql_query(
-        query=raw_query,
-        space_key=raw_space,
-    )
-
-    expected_space = raw_space.strip().replace("\\", "\\\\").replace('"', '\\"')
-    expected_query = raw_query.strip().replace("\\", "\\\\").replace('"', '\\"')
-
-    assert f'space="{expected_space}"' in cql
-    assert f'text~"{expected_query}"' in cql
-    assert cql.endswith('ORDER BY lastmodified DESC')
-
-
-def test_build_v2_payload_normalizes_inputs():
-    client = ConfluenceClient(
-        {
-            "server_type": "cloud",
-            "subdomain": "example",
-            "username": "user",
-            "token": "token",
-        }
-    )
-
-    raw_query = '  Demo  "story"  '
-    payload = client._build_v2_payload(
-        query=raw_query,
-        limit=5,
-        space_key=' SPACE ',
-    )
-
-    expected_query = raw_query.strip().replace("\\", "\\\\").replace('"', '\\"')
-
-    assert payload["queryString"] == f'text ~ "{expected_query}"'
-    assert payload["limit"] == 5
-    assert payload["spaceKeys"] == ["SPACE"]
-
+    assert response["results"] == []
+    assert response["output"] == "HTTP 400: cql query parameter is required"
+    assert trace.attributes["search"]["attempts"] == ["failure"]
 
 
 def test_tool_invoke_sanitizes_inputs():
     tool_instance = ConfluenceSearchPagesTool()
+    tool_instance.config = {}
 
     captured = {}
 
@@ -403,7 +319,7 @@ def test_tool_invoke_sanitizes_inputs():
             captured["query"] = query
             captured["limit"] = limit
             captured["space_key"] = space_key
-            return {"results": [], "source": "v1", "attempts": []}
+            return {"results": [], "source": "confluence", "attempts": []}
 
     tool_instance.client = DummyClient()
 
@@ -418,8 +334,6 @@ def test_tool_invoke_sanitizes_inputs():
     assert trace.inputs["query"] == "trimmed"
     assert trace.inputs["limit"] == 3
     assert trace.inputs["space_key"] is None
-    assert trace.attributes["config"]["limit"] == 3
-    assert trace.attributes["search"]["source"] == "v1"
-    assert trace.attributes["search"]["space_key"] is None
+    assert trace.outputs["results"] == []
     assert result["results"] == []
     assert result["output"] == "No Confluence pages matched your query."


### PR DESCRIPTION
## Summary
- replace the Confluence REST helper with a streamlined /rest/api/search implementation that normalizes results and surfaces errors clearly
- update the search pages tool to honor configured defaults for space key and limit
- refresh the Confluence search unit tests to validate the new client behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e515e86540832788552a4f2410cc86