### PR TITLE
Add form layout for Confluence search filters

### DIFF
--- a/python-agent-tools/search-confluence-pages/form.json
+++ b/python-agent-tools/search-confluence-pages/form.json
@@ -1,0 +1,39 @@
+{
+    "sections": [
+        {
+            "title": "Connection",
+            "fields": [
+                {"name": "access_type"},
+                {"name": "token_access"}
+            ]
+        },
+        {
+            "title": "Search scope",
+            "fields": [
+                {"name": "space_key"},
+                {"name": "type"},
+                {"name": "labels"}
+            ]
+        },
+        {
+            "title": "People filters",
+            "fields": [
+                {"name": "creator"},
+                {"name": "contributor"}
+            ]
+        },
+        {
+            "title": "Freshness",
+            "fields": [
+                {"name": "last_modified"}
+            ]
+        },
+        {
+            "title": "Ordering & pagination",
+            "fields": [
+                {"name": "order_by"},
+                {"name": "limit"}
+            ]
+        }
+    ]
+}

--- a/python-agent-tools/search-confluence-pages/tool.json
+++ b/python-agent-tools/search-confluence-pages/tool.json
@@ -31,6 +31,64 @@
             "optional": true
         },
         {
+            "name": "type",
+            "label": "Content type",
+            "type": "STRING",
+            "description": "Optional Confluence content type filter (e.g. page, blogpost, attachment). Leave empty to search pages only.",
+            "optional": true
+        },
+        {
+            "name": "labels",
+            "label": "Labels",
+            "type": "STRING",
+            "description": "Comma-separated Confluence labels to filter results (e.g. docs,how-to).",
+            "optional": true
+        },
+        {
+            "name": "creator",
+            "label": "Creator",
+            "type": "STRING",
+            "description": "Filter by creator username or account identifier.",
+            "optional": true
+        },
+        {
+            "name": "contributor",
+            "label": "Contributor",
+            "type": "STRING",
+            "description": "Filter by contributor username or account identifier.",
+            "optional": true
+        },
+        {
+            "name": "last_modified",
+            "label": "Last modified",
+            "type": "SELECT",
+            "optional": true,
+            "description": "Limit results to pages updated within the selected timeframe.",
+            "selectChoices": [
+                {"value": "today", "label": "Today"},
+                {"value": "yesterday", "label": "Yesterday"},
+                {"value": "last_week", "label": "Last week"},
+                {"value": "last_4_weeks", "label": "Last 4 weeks"},
+                {"value": "last_3_months", "label": "Last 3 months"},
+                {"value": "last_year", "label": "Last year"}
+            ]
+        },
+        {
+            "name": "order_by",
+            "label": "Order by",
+            "type": "SELECT",
+            "optional": true,
+            "description": "Sort order for results (default: last modified descending).",
+            "selectChoices": [
+                {"value": "lastmodified_desc", "label": "Last modified (newest first)"},
+                {"value": "lastmodified_asc", "label": "Last modified (oldest first)"},
+                {"value": "created_desc", "label": "Created (newest first)"},
+                {"value": "created_asc", "label": "Created (oldest first)"},
+                {"value": "title_asc", "label": "Title (A-Z)"},
+                {"value": "title_desc", "label": "Title (Z-A)"}
+            ]
+        },
+        {
             "name": "limit",
             "label": "Documents limit",
             "type": "STRING",

--- a/python-agent-tools/search-confluence-pages/tool.py
+++ b/python-agent-tools/search-confluence-pages/tool.py
@@ -36,6 +36,46 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
                         "type": "string",
                         "description": "Optional Confluence space key to restrict the search. Leave empty to search all spaces.",
                     },
+                    "type": {
+                        "type": "string",
+                        "description": "Optional Confluence content type filter (e.g. page, blogpost, attachment). Leave empty to search pages only.",
+                    },
+                    "labels": {
+                        "type": "string",
+                        "description": "Comma-separated Confluence labels to filter results (e.g. docs,how-to).",
+                    },
+                    "creator": {
+                        "type": "string",
+                        "description": "Filter by creator username or account identifier.",
+                    },
+                    "contributor": {
+                        "type": "string",
+                        "description": "Filter by contributor username or account identifier.",
+                    },
+                    "last_modified": {
+                        "type": "string",
+                        "enum": [
+                            "today",
+                            "yesterday",
+                            "last_week",
+                            "last_4_weeks",
+                            "last_3_months",
+                            "last_year",
+                        ],
+                        "description": "Limit results to pages updated within the selected timeframe.",
+                    },
+                    "order_by": {
+                        "type": "string",
+                        "enum": [
+                            "lastmodified_desc",
+                            "lastmodified_asc",
+                            "created_desc",
+                            "created_asc",
+                            "title_asc",
+                            "title_desc",
+                        ],
+                        "description": "Sort order for results (default: lastmodified_desc).",
+                    },
                     "limit": {
                         "type": "integer",
                         "description": "Maximum number of results to return (default: 3).",
@@ -64,9 +104,79 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
         text_value = str(space_key).strip()
         return text_value or None
 
+    @staticmethod
+    def _normalize_text(value):
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _normalize_labels(labels):
+        if labels is None:
+            return []
+        if isinstance(labels, str):
+            raw_items = labels.replace(";", ",").split(",")
+        elif isinstance(labels, (list, tuple, set)):
+            raw_items = labels
+        else:
+            raw_items = [labels]
+
+        normalized = []
+        for item in raw_items:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                normalized.append(text)
+        return normalized
+
+    @staticmethod
+    def _normalize_last_modified(value):
+        if value is None:
+            return None
+        text = str(value).strip().lower().replace("-", "_")
+        if not text:
+            return None
+        allowed = {
+            "today",
+            "yesterday",
+            "last_week",
+            "last_4_weeks",
+            "last_3_months",
+            "last_year",
+        }
+        return text if text in allowed else None
+
+    @staticmethod
+    def _normalize_order_by(value):
+        if value is None:
+            return "lastmodified_desc"
+        text = str(value).strip().lower().replace(" ", "_")
+        if not text:
+            return "lastmodified_desc"
+        mapping = {
+            "lastmodified": "lastmodified_desc",
+            "lastmodified_desc": "lastmodified_desc",
+            "lastmodified_asc": "lastmodified_asc",
+            "created": "created_desc",
+            "created_desc": "created_desc",
+            "created_asc": "created_asc",
+            "title": "title_asc",
+            "title_asc": "title_asc",
+            "title_desc": "title_desc",
+        }
+        return mapping.get(text, "lastmodified_desc")
+
     def search_pages(self, query: str, space_key: str = None, limit: int = 3):
         try:
-            return self.client.search_pages(query, limit=limit, space_key=space_key)
+            filters = getattr(self, "_current_filters", {})
+            return self.client.search_pages(
+                query, limit=limit, space_key=space_key, filters=filters
+            )
         except Exception as exception:
             return {
                 "results": [],
@@ -97,6 +207,76 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
             args.get("limit", default_limit), default=default_limit
         )
 
+        filters = {"type": "page"}
+        if isinstance(getattr(self, "config", None), dict):
+            default_type = self._normalize_text(
+                self.config.get("type") or self.config.get("content_type")
+            )
+            if default_type:
+                filters["type"] = default_type.lower()
+
+            default_labels = self._normalize_labels(self.config.get("labels"))
+            if default_labels:
+                filters["labels"] = default_labels
+
+            default_creator = self._normalize_text(self.config.get("creator"))
+            if default_creator:
+                filters["creator"] = default_creator
+
+            default_contributor = self._normalize_text(self.config.get("contributor"))
+            if default_contributor:
+                filters["contributor"] = default_contributor
+
+            default_last_modified = self._normalize_last_modified(
+                self.config.get("last_modified")
+            )
+            if default_last_modified:
+                filters["last_modified"] = default_last_modified
+
+            if "order_by" in self.config:
+                default_order = self._normalize_order_by(self.config.get("order_by"))
+                if default_order:
+                    filters["order_by"] = default_order
+
+        if "type" in args:
+            type_value = self._normalize_text(args.get("type"))
+            filters["type"] = (type_value or "page").lower()
+
+        if "labels" in args:
+            labels_value = self._normalize_labels(args.get("labels"))
+            if labels_value:
+                filters["labels"] = labels_value
+            elif "labels" in filters:
+                filters.pop("labels")
+
+        if "creator" in args:
+            creator_value = self._normalize_text(args.get("creator"))
+            if creator_value:
+                filters["creator"] = creator_value
+            elif "creator" in filters:
+                filters.pop("creator")
+
+        if "contributor" in args:
+            contributor_value = self._normalize_text(args.get("contributor"))
+            if contributor_value:
+                filters["contributor"] = contributor_value
+            elif "contributor" in filters:
+                filters.pop("contributor")
+
+        if "last_modified" in args:
+            last_modified_value = self._normalize_last_modified(args.get("last_modified"))
+            if last_modified_value:
+                filters["last_modified"] = last_modified_value
+            elif "last_modified" in filters:
+                filters.pop("last_modified")
+
+        if "order_by" in args:
+            order_value = self._normalize_order_by(args.get("order_by"))
+            if order_value:
+                filters["order_by"] = order_value
+
+        self._current_filters = filters
+
         confluence_instance_url = self.client.site_url or ""
         base_url = (
             f"{confluence_instance_url.rstrip('/')}/"
@@ -115,6 +295,7 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
             "confluence_instance_url": confluence_instance_url,
             "limit": limit_value,
             "space_key": space_key,
+            "filters": filters,
         }
 
         search_result = self.search_pages(query, space_key, limit_value)
@@ -126,6 +307,7 @@ class ConfluenceSearchPagesTool(BaseAgentTool):
                 "source": search_result.get("source"),
                 "attempts": search_result.get("attempts"),
                 "space_key": space_key,
+                "filters": filters,
             }
 
 

--- a/python-lib/confluence_client.py
+++ b/python-lib/confluence_client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 from urllib.parse import urlencode, urljoin
 
 import requests
@@ -80,9 +80,107 @@ class ConfluenceClient:
             return default
         return parsed if parsed > 0 else default
 
+    @staticmethod
+    def _normalize_labels(labels: Any) -> List[str]:
+        if labels is None:
+            return []
+        if isinstance(labels, str):
+            raw_items: Iterable[str] = labels.replace(";", ",").split(",")
+        elif isinstance(labels, Iterable):
+            raw_items = labels  # type: ignore[assignment]
+        else:
+            raw_items = [str(labels)]
+
+        normalized: List[str] = []
+        for item in raw_items:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                normalized.append(text)
+        return normalized
+
+    @staticmethod
+    def _normalize_user_reference(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _normalize_order_by(value: Any) -> str:
+        if value is None:
+            return "lastmodified DESC"
+
+        text = str(value).strip()
+        if not text:
+            return "lastmodified DESC"
+
+        normalized = text.lower().replace("-", "_")
+        shorthand_map = {
+            "last_modified": "lastmodified DESC",
+            "last_modified_desc": "lastmodified DESC",
+            "last_modified_asc": "lastmodified ASC",
+            "lastmodified": "lastmodified DESC",
+            "lastmodified_desc": "lastmodified DESC",
+            "lastmodified_asc": "lastmodified ASC",
+            "created": "created DESC",
+            "created_desc": "created DESC",
+            "created_asc": "created ASC",
+            "title": "title ASC",
+            "title_asc": "title ASC",
+            "title_desc": "title DESC",
+        }
+
+        if normalized in shorthand_map:
+            return shorthand_map[normalized]
+
+        tokens = text.split()
+        if tokens:
+            field = tokens[0].lower()
+            direction = tokens[1].upper() if len(tokens) > 1 else "DESC"
+            if field in {"lastmodified", "created", "title"} and direction in {"ASC", "DESC"}:
+                return f"{field} {direction}"
+
+        return "lastmodified DESC"
+
+    @staticmethod
+    def _normalize_last_modified(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip().lower().replace("-", "_")
+        if not text:
+            return None
+
+        mapping = {
+            "today": "lastmodified >= startOfDay()",
+            "yesterday": "lastmodified >= startOfDay(-1d)",
+            "last_week": "lastmodified >= startOfDay(-7d)",
+            "last_4_weeks": "lastmodified >= startOfDay(-28d)",
+            "last_four_weeks": "lastmodified >= startOfDay(-28d)",
+            "last_month": "lastmodified >= startOfDay(-31d)",
+            "last_3_months": "lastmodified >= startOfDay(-12w)",
+            "last_three_months": "lastmodified >= startOfDay(-12w)",
+            "last_year": "lastmodified >= startOfDay(-52w)",
+            "past_day": "lastmodified >= startOfDay(-1d)",
+            "past_week": "lastmodified >= startOfDay(-7d)",
+            "past_month": "lastmodified >= startOfDay(-31d)",
+        }
+
+        return mapping.get(text)
+
     # ------------------------------- public API --------------------------------
 
-    def search_pages(self, query: str, limit: int = 3, space_key: Optional[str] = None) -> Dict[str, Any]:
+    def search_pages(
+        self,
+        query: str,
+        limit: int = 3,
+        space_key: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         attempts: List[str] = []
 
         limit_value = self._coerce_positive_int(limit, default=3)
@@ -91,13 +189,47 @@ class ConfluenceClient:
         if qtext.endswith("?"):
             qtext = qtext[:-1].strip()
 
-        cql_parts = ["type=page"]
+        filters = filters or {}
+
+        content_type = filters.get("type")
+        if content_type is None:
+            cql_parts = ["type = \"page\""]
+        else:
+            content_type_text = str(content_type).strip()
+            if not content_type_text:
+                cql_parts = ["type = \"page\""]
+            elif content_type_text.lower() == "page":
+                cql_parts = ["type = \"page\""]
+            else:
+                cql_parts = [f'type = "{self._escape_cql_value(content_type_text)}"']
+
         if space_key := self._normalize_space_key(space_key):
             cql_parts.append(f'space = "{self._escape_cql_value(space_key)}"')
+
+        labels = self._normalize_labels(filters.get("labels"))
+        for label in labels:
+            cql_parts.append(f'label = "{self._escape_cql_value(label)}"')
+
+        creator = self._normalize_user_reference(filters.get("creator"))
+        if creator:
+            cql_parts.append(f'creator = "{self._escape_cql_value(creator)}"')
+
+        contributor = self._normalize_user_reference(filters.get("contributor"))
+        if contributor:
+            cql_parts.append(f'contributor = "{self._escape_cql_value(contributor)}"')
+
+        last_modified_clause = self._normalize_last_modified(filters.get("last_modified"))
+        if last_modified_clause:
+            cql_parts.append(last_modified_clause)
+
         if qtext:
             cql_parts.append(f'text ~ "{self._escape_cql_value(qtext)}"')
 
-        cql = " AND ".join(cql_parts) + " ORDER BY lastmodified DESC"
+        order_by_clause = self._normalize_order_by(filters.get("order_by"))
+
+        cql = " AND ".join(cql_parts)
+        if order_by_clause:
+            cql = f"{cql} ORDER BY {order_by_clause}"
         attempts.append(f"CQL={cql}")
 
         url = f"{self.base_url}/rest/api/search"

--- a/tests/python/unit/test_confluence_search_tool.py
+++ b/tests/python/unit/test_confluence_search_tool.py
@@ -166,14 +166,48 @@ def test_confluence_client_search_pages_builds_expected_cql(monkeypatch):
     assert captured["params"]["limit"] == 3
     assert (
         captured["params"]["cql"]
-        == 'type=page AND space = "AIEC" AND text ~ "what is Dataiku" ORDER BY lastmodified DESC'
+        == 'type = "page" AND space = "AIEC" AND text ~ "what is Dataiku" ORDER BY lastmodified DESC'
     )
     assert result["attempts"][0] == (
-        'CQL=type=page AND space = "AIEC" AND text ~ "what is Dataiku" ORDER BY lastmodified DESC'
+        'CQL=type = "page" AND space = "AIEC" AND text ~ "what is Dataiku" ORDER BY lastmodified DESC'
     )
     assert result["attempts"][1].startswith("GET")
     assert result["results"][0]["url"].endswith("/display/AIEC/Dataiku")
     assert result["results"][0]["space_key"] == "AIEC"
+
+
+def test_confluence_client_search_pages_applies_filters(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, url, params=None, **kwargs):
+        captured["params"] = params
+        return DummyResponse(payload={"results": []})
+
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+
+    client = ConfluenceClient({"api_url": "https://confluence.example.com/"})
+
+    client.search_pages(
+        "analytics",
+        limit=10,
+        filters={
+            "type": "blogpost",
+            "labels": ["release", "internal"],
+            "creator": "jsmith",
+            "contributor": "adoe",
+            "last_modified": "last_week",
+            "order_by": "created_asc",
+        },
+    )
+
+    cql = captured["params"]["cql"]
+    assert 'type = "blogpost"' in cql
+    assert 'label = "release"' in cql
+    assert 'label = "internal"' in cql
+    assert 'creator = "jsmith"' in cql
+    assert 'contributor = "adoe"' in cql
+    assert 'lastmodified >= startOfDay(-7d)' in cql
+    assert cql.endswith("ORDER BY created ASC")
 
 
 def test_confluence_client_search_pages_handles_error(monkeypatch):
@@ -250,10 +284,11 @@ def test_tool_invoke_uses_defaults_and_fetches_page_content():
     class DummyClient:
         site_url = "https://confluence.example.com/"
 
-        def search_pages(self, query, limit=None, space_key=None):
+        def search_pages(self, query, limit=None, space_key=None, filters=None):
             recorded["query"] = query
             recorded["limit"] = limit
             recorded["space_key"] = space_key
+            recorded["filters"] = filters
             return {
                 "results": [
                     {
@@ -275,10 +310,16 @@ def test_tool_invoke_uses_defaults_and_fetches_page_content():
     trace = DummyTrace()
     response = tool.invoke({"input": {"query": "Dataiku"}}, trace)
 
-    assert recorded == {"query": "Dataiku", "limit": 5, "space_key": "AIEC"}
+    assert recorded == {
+        "query": "Dataiku",
+        "limit": 5,
+        "space_key": "AIEC",
+        "filters": {"type": "page"},
+    }
     assert len(response["results"]) == 1
     assert response["results"][0]["page_content"] == "<p>Content</p>"
     assert trace.outputs["results"][0]["url"].endswith("/display/AIEC/Dataiku")
+    assert trace.attributes["config"]["filters"] == {"type": "page"}
 
 
 def test_tool_invoke_surfaces_error_message():
@@ -287,7 +328,7 @@ def test_tool_invoke_surfaces_error_message():
     class DummyClient:
         site_url = "https://confluence.example.com/"
 
-        def search_pages(self, query, limit=None, space_key=None):
+        def search_pages(self, query, limit=None, space_key=None, filters=None):
             return {
                 "results": [],
                 "error": {"message": "HTTP 400: cql query parameter is required"},
@@ -315,10 +356,11 @@ def test_tool_invoke_sanitizes_inputs():
     class DummyClient:
         site_url = "https://confluence.example.com/"
 
-        def search_pages(self, query, limit=3, space_key=None):
+        def search_pages(self, query, limit=3, space_key=None, filters=None):
             captured["query"] = query
             captured["limit"] = limit
             captured["space_key"] = space_key
+            captured["filters"] = filters
             return {"results": [], "source": "confluence", "attempts": []}
 
     tool_instance.client = DummyClient()
@@ -326,14 +368,38 @@ def test_tool_invoke_sanitizes_inputs():
     trace = DummyTrace()
 
     result = tool_instance.invoke(
-        {"input": {"query": "  trimmed  ", "space_key": "   ", "limit": "invalid"}},
+        {
+            "input": {
+                "query": "  trimmed  ",
+                "space_key": "   ",
+                "limit": "invalid",
+                "type": "  BLOGPOST  ",
+                "labels": " tag-one , tag-two ",
+                "creator": "  user1  ",
+                "contributor": "   ",
+                "last_modified": "Last_Week",
+                "order_by": "created asc",
+            }
+        },
         trace,
     )
 
-    assert captured == {"query": "trimmed", "limit": 3, "space_key": None}
+    assert captured == {
+        "query": "trimmed",
+        "limit": 3,
+        "space_key": None,
+        "filters": {
+            "type": "blogpost",
+            "labels": ["tag-one", "tag-two"],
+            "creator": "user1",
+            "last_modified": "last_week",
+            "order_by": "created_asc",
+        },
+    }
     assert trace.inputs["query"] == "trimmed"
     assert trace.inputs["limit"] == 3
     assert trace.inputs["space_key"] is None
+    assert trace.attributes["config"]["filters"]["type"] == "blogpost"
     assert trace.outputs["results"] == []
     assert result["results"] == []
     assert result["output"] == "No Confluence pages matched your query."


### PR DESCRIPTION
## Summary
- add a dedicated form layout for the Confluence search agent tool so the new filter parameters are exposed in the UI

## Testing
- pytest tests/python/unit/test_confluence_search_tool.py

------
https://chatgpt.com/codex/tasks/task_e_6908c2593edc83279ef428a473a29503